### PR TITLE
feat: add FeedSourceRepository (#5)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,8 +52,10 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/kotlin/com/hopescrolling/data/feed/DataStoreFeedSourceRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/feed/DataStoreFeedSourceRepository.kt
@@ -1,0 +1,50 @@
+package com.hopescrolling.data.feed
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class DataStoreFeedSourceRepository(
+    private val dataStore: DataStore<Preferences>
+) : FeedSourceRepository {
+
+    private val SOURCE_IDS = stringSetPreferencesKey("source_ids")
+
+    private fun nameKey(id: String) = stringPreferencesKey("source_name_$id")
+    private fun urlKey(id: String) = stringPreferencesKey("source_url_$id")
+
+    override fun getAll(): Flow<List<FeedSource>> {
+        return dataStore.data.map { prefs ->
+            val ids = prefs[SOURCE_IDS] ?: emptySet()
+            ids.mapNotNull { id ->
+                val name = prefs[nameKey(id)] ?: return@mapNotNull null
+                val url = prefs[urlKey(id)] ?: return@mapNotNull null
+                FeedSource(id = id, name = name, url = url)
+            }
+        }
+    }
+
+    override suspend fun add(source: FeedSource) {
+        dataStore.edit { prefs ->
+            val ids = prefs[SOURCE_IDS]?.toMutableSet() ?: mutableSetOf()
+            ids.add(source.id)
+            prefs[SOURCE_IDS] = ids
+            prefs[nameKey(source.id)] = source.name
+            prefs[urlKey(source.id)] = source.url
+        }
+    }
+
+    override suspend fun remove(id: String) {
+        dataStore.edit { prefs ->
+            val ids = prefs[SOURCE_IDS]?.toMutableSet() ?: mutableSetOf()
+            ids.remove(id)
+            prefs[SOURCE_IDS] = ids
+            prefs.remove(nameKey(id))
+            prefs.remove(urlKey(id))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSource.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSource.kt
@@ -1,0 +1,3 @@
+package com.hopescrolling.data.feed
+
+data class FeedSource(val id: String, val name: String, val url: String)

--- a/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSourceRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSourceRepository.kt
@@ -1,0 +1,9 @@
+package com.hopescrolling.data.feed
+
+import kotlinx.coroutines.flow.Flow
+
+interface FeedSourceRepository {
+    fun getAll(): Flow<List<FeedSource>>
+    suspend fun add(source: FeedSource)
+    suspend fun remove(id: String)
+}

--- a/app/src/test/kotlin/com/hopescrolling/data/feed/FeedSourceRepositoryTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/feed/FeedSourceRepositoryTest.kt
@@ -1,0 +1,60 @@
+package com.hopescrolling.data.feed
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FeedSourceRepositoryTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private fun createRepository(): FeedSourceRepository {
+        val dataStore = PreferenceDataStoreFactory.create {
+            temporaryFolder.newFile("test.preferences_pb")
+        }
+        return DataStoreFeedSourceRepository(dataStore)
+    }
+
+    @Test
+    fun `fresh repository emits empty list`() = runTest {
+        val repo = createRepository()
+        val result = repo.getAll().first()
+        assertEquals(emptyList<FeedSource>(), result)
+    }
+
+    @Test
+    fun `add a source and getAll emits list containing that source`() = runTest {
+        val repo = createRepository()
+        val source = FeedSource(id = "1", name = "Test Feed", url = "https://example.com/feed")
+        repo.add(source)
+        val result = repo.getAll().first()
+        assertEquals(listOf(source), result)
+    }
+
+    @Test
+    fun `remove an added source and getAll no longer contains it`() = runTest {
+        val repo = createRepository()
+        val source = FeedSource(id = "1", name = "Test Feed", url = "https://example.com/feed")
+        repo.add(source)
+        repo.remove(source.id)
+        val result = repo.getAll().first()
+        assertEquals(emptyList<FeedSource>(), result)
+    }
+
+    @Test
+    fun `add two sources remove one only the other remains`() = runTest {
+        val repo = createRepository()
+        val source1 = FeedSource(id = "1", name = "Feed One", url = "https://example.com/feed1")
+        val source2 = FeedSource(id = "2", name = "Feed Two", url = "https://example.com/feed2")
+        repo.add(source1)
+        repo.add(source2)
+        repo.remove(source1.id)
+        val result = repo.getAll().first()
+        assertEquals(listOf(source2), result)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ navigationCompose = "2.8.5"
 junit = "4.13.2"
 junitExt = "1.2.1"
 espressoCore = "3.6.1"
+datastore = "1.1.1"
+kotlinx-coroutines = "1.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,6 +28,8 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitExt" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Adds `FeedSourceRepository` interface and `DataStoreFeedSourceRepository` implementation
- DataStore-backed CRUD for feed source URLs and names
- Includes unit tests

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)