### PR TITLE
[#6] feat: implement FeedManagerScreen and FeedManagerViewModel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## General rules
+
+Never `git push` unless explicitly told to.
+
+Each PR must have exactly one commit. All fixes and follow-ups go into the same commit via `git commit --amend`, not as new commits.
+
 ## Commands
 
 `gradlew` is patched to fall back to Android Studio's JDK when `JAVA_HOME` is not set — no `JAVA_HOME` export needed locally. `org.gradle.java.home` is intentionally absent from `gradle.properties` so CI can use its own JDK.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,12 @@ android {
     buildFeatures {
         compose = true
     }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -56,6 +62,9 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -63,5 +72,5 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    implementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/src/main/kotlin/com/hopescrolling/data/feed/DataStoreFeedSourceRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/feed/DataStoreFeedSourceRepository.kt
@@ -47,4 +47,11 @@ class DataStoreFeedSourceRepository(
             prefs.remove(urlKey(id))
         }
     }
+
+    override suspend fun update(source: FeedSource) {
+        dataStore.edit { prefs ->
+            prefs[nameKey(source.id)] = source.name
+            prefs[urlKey(source.id)] = source.url
+        }
+    }
 }

--- a/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSourceDataStore.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSourceDataStore.kt
@@ -1,0 +1,8 @@
+package com.hopescrolling.data.feed
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.feedSourceDataStore: DataStore<Preferences> by preferencesDataStore(name = "feed_sources")

--- a/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSourceRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/feed/FeedSourceRepository.kt
@@ -6,4 +6,5 @@ interface FeedSourceRepository {
     fun getAll(): Flow<List<FeedSource>>
     suspend fun add(source: FeedSource)
     suspend fun remove(id: String)
+    suspend fun update(source: FeedSource)
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -10,13 +10,19 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.hopescrolling.data.feed.DataStoreFeedSourceRepository
+import com.hopescrolling.data.feed.feedSourceDataStore
 import com.hopescrolling.ui.screens.FeedManagerScreen
+import com.hopescrolling.ui.screens.FeedManagerViewModel
 import com.hopescrolling.ui.screens.TimelineScreen
 
 private const val ROUTE_TIMELINE = "timeline"
@@ -25,6 +31,10 @@ private const val ROUTE_FEED_MANAGER = "feed_manager"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppNavigation() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val repository = remember { DataStoreFeedSourceRepository(context.feedSourceDataStore) }
+    val feedManagerViewModel = remember { FeedManagerViewModel(repository, scope) }
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
@@ -61,7 +71,7 @@ fun AppNavigation() {
             startDestination = ROUTE_TIMELINE,
         ) {
             composable(ROUTE_TIMELINE) { TimelineScreen() }
-            composable(ROUTE_FEED_MANAGER) { FeedManagerScreen() }
+            composable(ROUTE_FEED_MANAGER) { FeedManagerScreen(feedManagerViewModel) }
         }
         // suppress unused padding warning — padding will be used once screens have content
         @Suppress("UNUSED_EXPRESSION")

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/FeedManagerScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/FeedManagerScreen.kt
@@ -1,21 +1,126 @@
 package com.hopescrolling.ui.screens
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.hopescrolling.data.feed.FeedSource
 
 @Composable
-fun FeedManagerScreen() {
-    Box(
+fun FeedManagerScreen(viewModel: FeedManagerViewModel) {
+    val feedSources by viewModel.feedSources.collectAsState()
+    var addUrl by remember { mutableStateOf("") }
+    var renameState by remember { mutableStateOf<Pair<FeedSource, String>?>(null) }
+
+    Column(
         modifier = Modifier
             .fillMaxSize()
-            .testTag("feed_manager_screen"),
-        contentAlignment = Alignment.Center,
+            .testTag("feed_manager_screen")
+            .padding(16.dp),
     ) {
-        Text("Feed Manager")
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = addUrl,
+                onValueChange = { addUrl = it },
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("add_feed_input"),
+                placeholder = { Text("Feed URL") },
+            )
+            Button(
+                onClick = {
+                    if (addUrl.isNotBlank()) {
+                        viewModel.addFeed(addUrl)
+                        addUrl = ""
+                    }
+                },
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .testTag("add_feed_button"),
+            ) {
+                Text("Add")
+            }
+        }
+
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            items(feedSources, key = { it.id }) { source ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                        .testTag("feed_item_${source.id}"),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = source.name,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(
+                        onClick = { renameState = source to source.name },
+                        modifier = Modifier.testTag("rename_feed_${source.id}"),
+                    ) {
+                        Text("R")
+                    }
+                    IconButton(
+                        onClick = { viewModel.deleteFeed(source.id) },
+                        modifier = Modifier.testTag("delete_feed_${source.id}"),
+                    ) {
+                        Text("X")
+                    }
+                }
+            }
+        }
+    }
+
+    renameState?.let { (source, input) ->
+        AlertDialog(
+            onDismissRequest = { renameState = null },
+            title = { Text("Rename") },
+            text = {
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = { renameState = source to it },
+                    modifier = Modifier.testTag("rename_dialog_input"),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (input.isNotBlank()) {
+                            viewModel.renameFeed(source.id, input)
+                            renameState = null
+                        }
+                    },
+                    modifier = Modifier.testTag("rename_dialog_confirm"),
+                ) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { renameState = null }) { Text("Cancel") }
+            },
+        )
     }
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModel.kt
@@ -1,0 +1,33 @@
+package com.hopescrolling.ui.screens
+
+import com.hopescrolling.data.feed.FeedSource
+import com.hopescrolling.data.feed.FeedSourceRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+class FeedManagerViewModel(
+    private val repository: FeedSourceRepository,
+    private val scope: CoroutineScope,
+) {
+    val feedSources: StateFlow<List<FeedSource>> = repository.getAll()
+        .stateIn(scope, SharingStarted.Eagerly, emptyList())
+
+    fun addFeed(url: String) {
+        scope.launch {
+            repository.add(FeedSource(id = UUID.randomUUID().toString(), name = url, url = url))
+        }
+    }
+
+    fun deleteFeed(id: String) {
+        scope.launch { repository.remove(id) }
+    }
+
+    fun renameFeed(id: String, newName: String) {
+        val current = feedSources.value.firstOrNull { it.id == id } ?: return
+        scope.launch { repository.update(current.copy(name = newName)) }
+    }
+}

--- a/app/src/test/AndroidManifest.xml
+++ b/app/src/test/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity android:name="androidx.activity.ComponentActivity" />
+    </application>
+</manifest>

--- a/app/src/test/kotlin/com/hopescrolling/NavigationTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/NavigationTest.kt
@@ -6,7 +6,10 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class NavigationTest {
 
     @get:Rule

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerScreenTest.kt
@@ -1,0 +1,119 @@
+package com.hopescrolling.ui.screens
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.AnnotatedString
+import com.hopescrolling.data.feed.FeedSource
+import com.hopescrolling.data.feed.FeedSourceRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class FeedManagerScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private class FakeFeedSourceRepository : FeedSourceRepository {
+        val sources = MutableStateFlow<List<FeedSource>>(emptyList())
+
+        override fun getAll(): Flow<List<FeedSource>> = sources
+
+        override suspend fun add(source: FeedSource) {
+            sources.value = sources.value + source
+        }
+
+        override suspend fun remove(id: String) {
+            sources.value = sources.value.filter { it.id != id }
+        }
+
+        override suspend fun update(source: FeedSource) {
+            sources.value = sources.value.map { if (it.id == source.id) source else it }
+        }
+    }
+
+    private fun viewModelScope(): CoroutineScope = TestScope(UnconfinedTestDispatcher())
+
+    @Test
+    fun feedManagerScreen_showsFeedSourceNames() {
+        val repo = FakeFeedSourceRepository()
+        repo.sources.value = listOf(
+            FeedSource(id = "1", name = "Tech Blog", url = "https://tech.example.com/feed"),
+            FeedSource(id = "2", name = "News Feed", url = "https://news.example.com/feed"),
+        )
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithText("Tech Blog").assertIsDisplayed()
+        composeTestRule.onNodeWithText("News Feed").assertIsDisplayed()
+    }
+
+    @Test
+    fun feedManagerScreen_hasAddInputAndButton() {
+        val viewModel = FeedManagerViewModel(FakeFeedSourceRepository(), viewModelScope())
+        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("add_feed_input").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("add_feed_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun feedManagerScreen_addingUrlAppearsInList() {
+        val repo = FakeFeedSourceRepository()
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("add_feed_input").performTextInput("https://example.com/rss")
+        composeTestRule.onNodeWithTag("add_feed_button").performClick()
+
+        composeTestRule.onNodeWithText("https://example.com/rss").assertIsDisplayed()
+    }
+
+    @Test
+    fun feedManagerScreen_deleteButtonRemovesItem() {
+        val repo = FakeFeedSourceRepository()
+        repo.sources.value = listOf(
+            FeedSource(id = "1", name = "Tech Blog", url = "https://tech.example.com/feed"),
+        )
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("delete_feed_1").performClick()
+
+        composeTestRule.onNodeWithText("Tech Blog").assertDoesNotExist()
+    }
+
+    @Test
+    fun feedManagerScreen_renameDialogUpdatesName() {
+        val repo = FakeFeedSourceRepository()
+        repo.sources.value = listOf(
+            FeedSource(id = "1", name = "Old Name", url = "https://example.com/feed"),
+        )
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("rename_feed_1").performClick()
+        composeTestRule.onNodeWithTag("rename_dialog_input").assert(hasText("Old Name"))
+        composeTestRule.onNodeWithTag("rename_dialog_input")
+            .performSemanticsAction(SemanticsActions.SetText) { it(AnnotatedString("New Name")) }
+        composeTestRule.onNodeWithTag("rename_dialog_confirm").performClick()
+
+        composeTestRule.onNodeWithText("New Name").assertIsDisplayed()
+    }
+}

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModelTest.kt
@@ -1,0 +1,84 @@
+package com.hopescrolling.ui.screens
+
+import com.hopescrolling.data.feed.FeedSource
+import com.hopescrolling.data.feed.FeedSourceRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FeedManagerViewModelTest {
+
+    private class FakeFeedSourceRepository : FeedSourceRepository {
+        private val sources = MutableStateFlow<List<FeedSource>>(emptyList())
+
+        override fun getAll(): Flow<List<FeedSource>> = sources
+
+        override suspend fun add(source: FeedSource) {
+            sources.value = sources.value + source
+        }
+
+        override suspend fun remove(id: String) {
+            sources.value = sources.value.filter { it.id != id }
+        }
+
+        override suspend fun update(source: FeedSource) {
+            sources.value = sources.value.map { if (it.id == source.id) source else it }
+        }
+    }
+
+    private fun viewModelScope() = TestScope(UnconfinedTestDispatcher())
+
+    @Test
+    fun `renameFeed updates the name of the source with the given id`() = runTest {
+        val repo = FakeFeedSourceRepository()
+        val source = FeedSource(id = "1", name = "Old Name", url = "https://example.com/feed")
+        repo.add(source)
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+
+        viewModel.renameFeed("1", "New Name")
+
+        val updated = viewModel.feedSources.first().first { it.id == "1" }
+        assertEquals("New Name", updated.name)
+        assertEquals("https://example.com/feed", updated.url)
+    }
+
+    @Test
+    fun `deleteFeed removes the source with the given id`() = runTest {
+        val repo = FakeFeedSourceRepository()
+        val source = FeedSource(id = "1", name = "Feed", url = "https://example.com/feed")
+        repo.add(source)
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+
+        viewModel.deleteFeed("1")
+
+        assertEquals(emptyList<FeedSource>(), viewModel.feedSources.first())
+    }
+
+    @Test
+    fun `addFeed adds a source with the given url`() = runTest {
+        val repo = FakeFeedSourceRepository()
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+
+        viewModel.addFeed("https://example.com/feed")
+
+        val sources = viewModel.feedSources.first()
+        assertEquals(1, sources.size)
+        assertEquals("https://example.com/feed", sources[0].url)
+    }
+
+    @Test
+    fun `feedSources emits the list from the repository`() = runTest {
+        val repo = FakeFeedSourceRepository()
+        val source = FeedSource(id = "1", name = "Test Feed", url = "https://example.com/feed")
+        repo.add(source)
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+
+        assertEquals(listOf(source), viewModel.feedSources.first())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ junitExt = "1.2.1"
 espressoCore = "3.6.1"
 datastore = "1.1.1"
 kotlinx-coroutines = "1.9.0"
+robolectric = "4.14.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,6 +31,7 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

- Implements `FeedManagerViewModel` with `addFeed`, `deleteFeed`, and `renameFeed` operations backed by `FeedSourceRepository`
- Implements `FeedManagerScreen` with a URL input field, scrollable list of feed sources, and per-item delete + rename (via dialog)
- Adds `update()` to `FeedSourceRepository` interface and `DataStoreFeedSourceRepository`
- Wires DataStore → repository → ViewModel into `AppNavigation` (no DI framework)
- Migrates `NavigationTest` and `FeedManagerScreenTest` from instrumented (`androidTest`) to Robolectric (`test`) so all Compose UI tests run on the JVM — no emulator required in CI

## Test plan

- [ ] `./gradlew test` passes — all unit + Robolectric tests green
- [ ] Build debug APK: `./gradlew assembleDebug`
- [ ] Install on emulator and manually verify: add a feed URL, rename it, delete it, restart app and confirm persistence

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/claude-code)