### PR TITLE
fix: apply Scaffold padding so screen content isn't hidden behind top bar

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -69,12 +70,10 @@ fun AppNavigation() {
         NavHost(
             navController = navController,
             startDestination = ROUTE_TIMELINE,
+            modifier = Modifier.padding(padding),
         ) {
             composable(ROUTE_TIMELINE) { TimelineScreen() }
             composable(ROUTE_FEED_MANAGER) { FeedManagerScreen(feedManagerViewModel) }
         }
-        // suppress unused padding warning — padding will be used once screens have content
-        @Suppress("UNUSED_EXPRESSION")
-        padding
     }
 }


### PR DESCRIPTION
## Summary

- The `NavHost` was not receiving the `Scaffold` inner padding, causing all screen content to render behind the `TopAppBar` — making `FeedManagerScreen` appear blank

## Test plan

- [ ] Open Feed Manager (settings icon) — text field and Add button should be visible below the top bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)