### PR TITLE
[#15] ci: version releases by short SHA and keep rolling latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,19 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
-      - name: Publish rolling latest release
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish versioned release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: release-${{ steps.sha.outputs.short }}
+          name: release-${{ steps.sha.outputs.short }}
+          prerelease: true
+          files: app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Update rolling latest release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: latest


### PR DESCRIPTION
## Summary
- Each merge to main now creates a permanent `release-<sha>` GitHub release so old APKs are never overwritten
- The rolling `latest` release is still updated for convenient install links

## Test plan
- [ ] Merge to main and verify two releases are created: `release-<sha>` and `latest`
- [ ] Merge again and verify the previous `release-<sha>` release still exists

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/claude-code)