### PR TITLE
[#16] test: add Robolectric screenshot tests for UI iteration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ local.properties
 # OS
 .DS_Store
 Thumbs.db
+
+# Screenshots (generated locally by ScreenshotTest)
+screenshots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Each PR must have exactly one commit. All fixes and follow-ups go into the same 
 
 When asked to "automerge": fetch origin, check `git log origin/main..HEAD` and open PRs (`gh pr list`) to understand the current state, then create a PR for the latest commit and enable automerge (`gh pr merge --auto --rebase`).
 
-After every commit, launch a subagent to review it (`git show HEAD`) and report findings before proceeding.
+After every commit, launch a subagent to review it (`git show HEAD`) and report findings before proceeding. If the commit touches any amended files, re-run the review on the amended commit before considering the work done.
 
 ## Commands
 
@@ -21,7 +21,10 @@ After every commit, launch a subagent to review it (`git show HEAD`) and report 
 ./gradlew :app:testDebugUnitTest                # JVM unit tests
 ./gradlew :app:connectedDebugAndroidTest        # instrumented tests (requires emulator/device)
 ./gradlew :app:testDebugUnitTest --tests "com.hopescrolling.ThemeColorTest"  # single test class
+./gradlew :app:testDebugUnitTest -Pscreenshots --tests "com.hopescrolling.ScreenshotTest"  # screenshot tests (excluded from normal runs)
 ```
+
+After writing or changing any Compose UI code, run `./gradlew :app:testDebugUnitTest -Pscreenshots --tests "com.hopescrolling.ScreenshotTest"` and use the Read tool to inspect the PNGs in `screenshots/` to visually verify the layout. The directory is wiped and regenerated on each run.
 
 Emulator: `Pixel_7a` (Android 15). Launch app after installing:
 ```bash

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,11 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            all {
+                if (!project.hasProperty("screenshots")) {
+                    it.exclude("**/ScreenshotTest*")
+                }
+            }
         }
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
@@ -1,0 +1,88 @@
+package com.hopescrolling
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.hopescrolling.data.feed.FeedSource
+import com.hopescrolling.ui.screens.FeedManagerScreen
+import com.hopescrolling.ui.screens.FeedManagerViewModel
+import com.hopescrolling.ui.screens.TimelineScreen
+import com.hopescrolling.util.FakeFeedSourceRepository
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.io.File
+import java.io.FileOutputStream
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp-xxhdpi")
+@RunWith(RobolectricTestRunner::class)
+class ScreenshotTest {
+
+    companion object {
+        private val screenshotsDir = File("../screenshots")
+
+        @BeforeClass
+        @JvmStatic
+        fun clearScreenshots() {
+            screenshotsDir.deleteRecursively()
+            screenshotsDir.mkdirs()
+        }
+    }
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun viewModelScope() = TestScope(UnconfinedTestDispatcher())
+
+    private fun saveScreenshot(name: String) {
+        composeTestRule.waitForIdle()
+        val decorView = composeTestRule.activity.window.decorView
+        val bitmap = Bitmap.createBitmap(
+            decorView.width.coerceAtLeast(1),
+            decorView.height.coerceAtLeast(1),
+            Bitmap.Config.ARGB_8888
+        )
+        decorView.draw(Canvas(bitmap))
+        FileOutputStream(File(screenshotsDir, "$name.png")).use {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+
+    @Test
+    fun screenshot_timelineScreen() {
+        composeTestRule.setContent { TimelineScreen() }
+        saveScreenshot("timeline_screen")
+        assertTrue(File(screenshotsDir, "timeline_screen.png").exists())
+    }
+
+    @Test
+    fun screenshot_feedManagerScreen_empty() {
+        val viewModel = FeedManagerViewModel(FakeFeedSourceRepository(), viewModelScope())
+        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+        saveScreenshot("feed_manager_empty")
+        assertTrue(File(screenshotsDir, "feed_manager_empty.png").exists())
+    }
+
+    @Test
+    fun screenshot_feedManagerScreen_withFeeds() {
+        val repo = FakeFeedSourceRepository()
+        repo.sources.value = listOf(
+            FeedSource(id = "1", name = "Tech Blog", url = "https://tech.example.com/feed"),
+            FeedSource(id = "2", name = "News Feed", url = "https://news.example.com/feed"),
+        )
+        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+        saveScreenshot("feed_manager_with_feeds")
+        assertTrue(File(screenshotsDir, "feed_manager_with_feeds.png").exists())
+    }
+}

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerScreenTest.kt
@@ -12,10 +12,8 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.AnnotatedString
 import com.hopescrolling.data.feed.FeedSource
-import com.hopescrolling.data.feed.FeedSourceRepository
+import com.hopescrolling.util.FakeFeedSourceRepository
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
@@ -29,24 +27,6 @@ class FeedManagerScreenTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
-
-    private class FakeFeedSourceRepository : FeedSourceRepository {
-        val sources = MutableStateFlow<List<FeedSource>>(emptyList())
-
-        override fun getAll(): Flow<List<FeedSource>> = sources
-
-        override suspend fun add(source: FeedSource) {
-            sources.value = sources.value + source
-        }
-
-        override suspend fun remove(id: String) {
-            sources.value = sources.value.filter { it.id != id }
-        }
-
-        override suspend fun update(source: FeedSource) {
-            sources.value = sources.value.map { if (it.id == source.id) source else it }
-        }
-    }
 
     private fun viewModelScope(): CoroutineScope = TestScope(UnconfinedTestDispatcher())
 

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModelTest.kt
@@ -1,10 +1,7 @@
 package com.hopescrolling.ui.screens
 
 import com.hopescrolling.data.feed.FeedSource
-import com.hopescrolling.data.feed.FeedSourceRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
+import com.hopescrolling.util.FakeFeedSourceRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -12,25 +9,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class FeedManagerViewModelTest {
-
-    private class FakeFeedSourceRepository : FeedSourceRepository {
-        private val sources = MutableStateFlow<List<FeedSource>>(emptyList())
-
-        override fun getAll(): Flow<List<FeedSource>> = sources
-
-        override suspend fun add(source: FeedSource) {
-            sources.value = sources.value + source
-        }
-
-        override suspend fun remove(id: String) {
-            sources.value = sources.value.filter { it.id != id }
-        }
-
-        override suspend fun update(source: FeedSource) {
-            sources.value = sources.value.map { if (it.id == source.id) source else it }
-        }
-    }
 
     private fun viewModelScope() = TestScope(UnconfinedTestDispatcher())
 

--- a/app/src/test/kotlin/com/hopescrolling/util/FakeFeedSourceRepository.kt
+++ b/app/src/test/kotlin/com/hopescrolling/util/FakeFeedSourceRepository.kt
@@ -1,0 +1,24 @@
+package com.hopescrolling.util
+
+import com.hopescrolling.data.feed.FeedSource
+import com.hopescrolling.data.feed.FeedSourceRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeFeedSourceRepository : FeedSourceRepository {
+    val sources = MutableStateFlow<List<FeedSource>>(emptyList())
+
+    override fun getAll(): Flow<List<FeedSource>> = sources
+
+    override suspend fun add(source: FeedSource) {
+        sources.value = sources.value + source
+    }
+
+    override suspend fun remove(id: String) {
+        sources.value = sources.value.filter { it.id != id }
+    }
+
+    override suspend fun update(source: FeedSource) {
+        sources.value = sources.value.map { if (it.id == source.id) source else it }
+    }
+}


### PR DESCRIPTION
Closes #16

## Summary
- Adds `ScreenshotTest` with three Robolectric-based screenshot tests: `TimelineScreen`, `FeedManagerScreen` empty, and `FeedManagerScreen` with feeds
- Screenshots saved to `screenshots/` at repo root (wiped fresh on each run); excluded from standard test run via `-Pscreenshots` flag
- Extracts `FakeFeedSourceRepository` into a shared test util, removing duplication from `FeedManagerScreenTest` and `FeedManagerViewModelTest`

## Note on implementation
`captureToImage()` was ruled out — it relies on `ViewTreeObserver.OnDrawListener` which Robolectric never fires. `decorView.draw(Canvas(bitmap))` with `@GraphicsMode(NATIVE)` produces real Skia-rendered output instead.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` — ScreenshotTest does not run
- [ ] `./gradlew :app:testDebugUnitTest -Pscreenshots --tests "com.hopescrolling.ScreenshotTest"` — produces 3 PNGs in `screenshots/`
- [ ] `screenshots/` not tracked by git