### PR TITLE
[#8] feat: implement TimelineScreen, TimelineViewModel, and ArticleCard

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
@@ -1,5 +1,13 @@
 package com.hopescrolling.data.article
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.URL
+
 fun interface RssFeedFetcher {
     suspend fun fetch(url: String): String
+}
+
+fun httpRssFeedFetcher(): RssFeedFetcher = RssFeedFetcher { url ->
+    withContext(Dispatchers.IO) { URL(url).readText() }
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -20,11 +20,14 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.hopescrolling.data.article.DefaultArticleRepository
+import com.hopescrolling.data.article.httpRssFeedFetcher
 import com.hopescrolling.data.feed.DataStoreFeedSourceRepository
 import com.hopescrolling.data.feed.feedSourceDataStore
 import com.hopescrolling.ui.screens.FeedManagerScreen
 import com.hopescrolling.ui.screens.FeedManagerViewModel
 import com.hopescrolling.ui.screens.TimelineScreen
+import com.hopescrolling.ui.screens.TimelineViewModel
 
 private const val ROUTE_TIMELINE = "timeline"
 private const val ROUTE_FEED_MANAGER = "feed_manager"
@@ -34,8 +37,11 @@ private const val ROUTE_FEED_MANAGER = "feed_manager"
 fun AppNavigation() {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val repository = remember { DataStoreFeedSourceRepository(context.feedSourceDataStore) }
-    val feedManagerViewModel = remember { FeedManagerViewModel(repository, scope) }
+    val feedSourceRepository = remember { DataStoreFeedSourceRepository(context.feedSourceDataStore) }
+    val feedManagerViewModel = remember { FeedManagerViewModel(feedSourceRepository, scope) }
+    val rssFeedFetcher = remember { httpRssFeedFetcher() }
+    val articleRepository = remember { DefaultArticleRepository(feedSourceRepository, rssFeedFetcher) }
+    val timelineViewModel = remember { TimelineViewModel(articleRepository, scope) }
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
@@ -72,7 +78,7 @@ fun AppNavigation() {
             startDestination = ROUTE_TIMELINE,
             modifier = Modifier.padding(padding),
         ) {
-            composable(ROUTE_TIMELINE) { TimelineScreen() }
+            composable(ROUTE_TIMELINE) { TimelineScreen(timelineViewModel) }
             composable(ROUTE_FEED_MANAGER) { FeedManagerScreen(feedManagerViewModel) }
         }
     }

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
@@ -2,20 +2,70 @@ package com.hopescrolling.ui.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.hopescrolling.data.rss.Article
 
 @Composable
-fun TimelineScreen() {
+fun TimelineScreen(viewModel: TimelineViewModel) {
+    val uiState by viewModel.uiState.collectAsState()
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .testTag("timeline_screen"),
         contentAlignment = Alignment.Center,
     ) {
-        Text("Timeline")
+        when {
+            uiState.isLoading -> CircularProgressIndicator(
+                modifier = Modifier.testTag("timeline_loading"),
+            )
+            uiState.error != null -> Text(
+                text = uiState.error!!,
+                modifier = Modifier.testTag("timeline_error"),
+            )
+            uiState.articles.isEmpty() -> Text(
+                text = "No articles yet. Add feeds to get started.",
+                modifier = Modifier.testTag("timeline_empty"),
+            )
+            else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(uiState.articles) { article ->
+                    ArticleCard(article)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ArticleCard(article: Article) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag("article_card_${article.link}"),
+    ) {
+        Text(
+            text = article.title,
+            modifier = Modifier.padding(16.dp),
+        )
+        if (article.description != null) {
+            Text(
+                text = article.description,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
@@ -1,0 +1,34 @@
+package com.hopescrolling.ui.screens
+
+import com.hopescrolling.data.article.ArticleRepository
+import com.hopescrolling.data.rss.Article
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+data class TimelineUiState(
+    val articles: List<Article> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null,
+)
+
+class TimelineViewModel(
+    private val repository: ArticleRepository,
+    private val scope: CoroutineScope,
+) {
+    private val _uiState = MutableStateFlow(TimelineUiState())
+    val uiState: StateFlow<TimelineUiState> = _uiState
+
+    init {
+        scope.launch {
+            runCatching { repository.getArticles() }
+                .onSuccess { articles ->
+                    _uiState.value = TimelineUiState(articles = articles, isLoading = false)
+                }
+                .onFailure { e ->
+                    _uiState.value = TimelineUiState(isLoading = false, error = e.message ?: e::class.simpleName ?: "Unknown error")
+                }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
@@ -8,6 +8,9 @@ import com.hopescrolling.data.feed.FeedSource
 import com.hopescrolling.ui.screens.FeedManagerScreen
 import com.hopescrolling.ui.screens.FeedManagerViewModel
 import com.hopescrolling.ui.screens.TimelineScreen
+import com.hopescrolling.data.rss.Article
+import com.hopescrolling.ui.screens.TimelineViewModel
+import com.hopescrolling.util.FakeArticleRepository
 import com.hopescrolling.util.FakeFeedSourceRepository
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -60,7 +63,13 @@ class ScreenshotTest {
 
     @Test
     fun screenshot_timelineScreen() {
-        composeTestRule.setContent { TimelineScreen() }
+        val articles = listOf(
+            Article(title = "Android 16 Developer Preview Released", link = "https://a.com/1", description = "Google has released the first developer preview of Android 16, featuring new APIs for adaptive layouts.", pubDate = "Tue, 01 Apr 2026 09:00:00 GMT", feedSourceId = "android"),
+            Article(title = "Kotlin 2.2 Brings Improved Type Inference", link = "https://a.com/2", description = "The latest Kotlin release ships smarter type inference and faster incremental compilation.", pubDate = "Mon, 31 Mar 2026 14:30:00 GMT", feedSourceId = "kotlin"),
+            Article(title = "Jetpack Compose Stability Update", link = "https://a.com/3", description = null, pubDate = "Sun, 30 Mar 2026 08:00:00 GMT", feedSourceId = "android"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), viewModelScope())
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
         saveScreenshot("timeline_screen")
         assertTrue(File(screenshotsDir, "timeline_screen.png").exists())
     }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
@@ -1,0 +1,78 @@
+package com.hopescrolling.ui.screens
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.hopescrolling.data.rss.Article
+import com.hopescrolling.util.FakeArticleRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class TimelineScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun viewModelScope(): CoroutineScope = TestScope(UnconfinedTestDispatcher())
+
+    @Test
+    fun timelineScreen_showsLoadingIndicatorWhileLoading() {
+        val dispatcher = StandardTestDispatcher()
+        val repo = FakeArticleRepository()
+        val viewModel = TimelineViewModel(repo, TestScope(dispatcher))
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("timeline_loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsArticleTitles() {
+        val articles = listOf(
+            Article(title = "First Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
+            Article(title = "Second Post", link = "https://a.com/2", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), viewModelScope())
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithText("First Post").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Second Post").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsArticleDescription() {
+        val articles = listOf(
+            Article(title = "Post With Desc", link = "https://a.com/1", description = "A summary of the post", pubDate = null, feedSourceId = "f1"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), viewModelScope())
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithText("A summary of the post").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsErrorMessage() {
+        val repo = FakeArticleRepository(error = RuntimeException("could not load"))
+        val viewModel = TimelineViewModel(repo, viewModelScope())
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("timeline_error").assertIsDisplayed()
+        composeTestRule.onNodeWithText("could not load").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsEmptyStateWhenNoArticles() {
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = emptyList()), viewModelScope())
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("timeline_empty").assertIsDisplayed()
+    }
+}

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
@@ -1,0 +1,62 @@
+package com.hopescrolling.ui.screens
+
+import com.hopescrolling.data.rss.Article
+import com.hopescrolling.util.FakeArticleRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class TimelineViewModelTest {
+
+    private fun viewModelScope() = TestScope(UnconfinedTestDispatcher())
+
+    @Test
+    fun `uiState initially has isLoading true`() {
+        val dispatcher = StandardTestDispatcher()
+        val repo = FakeArticleRepository()
+        val viewModel = TimelineViewModel(repo, TestScope(dispatcher))
+
+        assertEquals(true, viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `uiState emits articles and isLoading false after load`() = runTest {
+        val articles = listOf(
+            Article(title = "First", link = "https://a.com/1", description = "Desc", pubDate = null, feedSourceId = "f1"),
+            Article(title = "Second", link = "https://a.com/2", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val repo = FakeArticleRepository(articles = articles)
+        val viewModel = TimelineViewModel(repo, viewModelScope())
+
+        val state = viewModel.uiState.first { !it.isLoading }
+
+        assertEquals(articles, state.articles)
+        assertEquals(null, state.error)
+    }
+
+    @Test
+    fun `uiState emits error and isLoading false when repository throws`() = runTest {
+        val repo = FakeArticleRepository(error = RuntimeException("network failure"))
+        val viewModel = TimelineViewModel(repo, viewModelScope())
+
+        val state = viewModel.uiState.first { !it.isLoading }
+
+        assertEquals(emptyList<Any>(), state.articles)
+        assertEquals("network failure", state.error)
+    }
+
+    @Test
+    fun `uiState emits non-null error when exception has no message`() = runTest {
+        val repo = FakeArticleRepository(error = RuntimeException())
+        val viewModel = TimelineViewModel(repo, viewModelScope())
+
+        val state = viewModel.uiState.first { !it.isLoading }
+
+        assertEquals(false, state.error.isNullOrBlank())
+    }
+}

--- a/app/src/test/kotlin/com/hopescrolling/util/FakeArticleRepository.kt
+++ b/app/src/test/kotlin/com/hopescrolling/util/FakeArticleRepository.kt
@@ -1,0 +1,14 @@
+package com.hopescrolling.util
+
+import com.hopescrolling.data.article.ArticleRepository
+import com.hopescrolling.data.rss.Article
+
+class FakeArticleRepository(
+    private val articles: List<Article> = emptyList(),
+    private val error: Throwable? = null,
+) : ArticleRepository {
+    override suspend fun getArticles(): List<Article> {
+        if (error != null) throw error
+        return articles
+    }
+}


### PR DESCRIPTION
## Summary

- `TimelineViewModel` fetches articles via `ArticleRepository` on init, exposing `TimelineUiState` (loading / articles / error)
- `TimelineScreen` shows a loading spinner, scrollable `ArticleCard` list, empty state, or error message
- `httpRssFeedFetcher()` factory added to the data layer (moved out of navigation)
- 9 new tests covering all ViewModel and screen states

## Pending (not in scope for this PR)

- Source name, pub date on cards
- Tap-to-open-browser
- ViewModel lifetime fix tracked in #21

## Test plan

- [ ] `./gradlew :app:testDebugUnitTest` passes
- [ ] Screenshot test shows article cards rendered correctly