### PR TITLE
[#26] fix: add timeout, non-2xx check to httpRssFeedFetcher

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
@@ -2,6 +2,8 @@ package com.hopescrolling.data.article
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.net.HttpURLConnection
 import java.net.URL
 
 fun interface RssFeedFetcher {
@@ -9,5 +11,18 @@ fun interface RssFeedFetcher {
 }
 
 fun httpRssFeedFetcher(): RssFeedFetcher = RssFeedFetcher { url ->
-    withContext(Dispatchers.IO) { URL(url).readText() }
+    withContext(Dispatchers.IO) {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        try {
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 30_000
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                throw IOException("HTTP $responseCode for $url")
+            }
+            connection.inputStream.bufferedReader().readText()
+        } finally {
+            connection.disconnect()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds 10s connect timeout and 30s read timeout via HttpURLConnection
- Throws IOException on non-2xx HTTP response codes
- Calls disconnect() in finally block

## Test plan
- [ ] Unit tests pass
- [ ] Manual: slow/unreachable server no longer hangs forever
- [ ] Manual: 404 response throws instead of returning HTML

Closes #26