### PR TITLE
[#21] fix: tie ViewModel lifetime to back-stack entry via lifecycle-viewmodel-compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,8 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -11,8 +11,8 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.foundation.layout.padding
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -36,12 +36,9 @@ private const val ROUTE_FEED_MANAGER = "feed_manager"
 @Composable
 fun AppNavigation() {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val feedSourceRepository = remember { DataStoreFeedSourceRepository(context.feedSourceDataStore) }
-    val feedManagerViewModel = remember { FeedManagerViewModel(feedSourceRepository, scope) }
     val rssFeedFetcher = remember { httpRssFeedFetcher() }
     val articleRepository = remember { DefaultArticleRepository(feedSourceRepository, rssFeedFetcher) }
-    val timelineViewModel = remember { TimelineViewModel(articleRepository, scope) }
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
@@ -78,8 +75,14 @@ fun AppNavigation() {
             startDestination = ROUTE_TIMELINE,
             modifier = Modifier.padding(padding),
         ) {
-            composable(ROUTE_TIMELINE) { TimelineScreen(timelineViewModel) }
-            composable(ROUTE_FEED_MANAGER) { FeedManagerScreen(feedManagerViewModel) }
+            composable(ROUTE_TIMELINE) {
+                val viewModel = viewModel { TimelineViewModel(articleRepository) }
+                TimelineScreen(viewModel)
+            }
+            composable(ROUTE_FEED_MANAGER) {
+                val viewModel = viewModel { FeedManagerViewModel(feedSourceRepository) }
+                FeedManagerScreen(viewModel)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModel.kt
@@ -1,8 +1,9 @@
 package com.hopescrolling.ui.screens
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.hopescrolling.data.feed.FeedSource
 import com.hopescrolling.data.feed.FeedSourceRepository
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -11,23 +12,22 @@ import java.util.UUID
 
 class FeedManagerViewModel(
     private val repository: FeedSourceRepository,
-    private val scope: CoroutineScope,
-) {
+) : ViewModel() {
     val feedSources: StateFlow<List<FeedSource>> = repository.getAll()
-        .stateIn(scope, SharingStarted.Eagerly, emptyList())
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     fun addFeed(url: String) {
-        scope.launch {
+        viewModelScope.launch {
             repository.add(FeedSource(id = UUID.randomUUID().toString(), name = url, url = url))
         }
     }
 
     fun deleteFeed(id: String) {
-        scope.launch { repository.remove(id) }
+        viewModelScope.launch { repository.remove(id) }
     }
 
     fun renameFeed(id: String, newName: String) {
         val current = feedSources.value.firstOrNull { it.id == id } ?: return
-        scope.launch { repository.update(current.copy(name = newName)) }
+        viewModelScope.launch { repository.update(current.copy(name = newName)) }
     }
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
@@ -1,8 +1,9 @@
 package com.hopescrolling.ui.screens
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.hopescrolling.data.article.ArticleRepository
 import com.hopescrolling.data.rss.Article
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -15,13 +16,12 @@ data class TimelineUiState(
 
 class TimelineViewModel(
     private val repository: ArticleRepository,
-    private val scope: CoroutineScope,
-) {
+) : ViewModel() {
     private val _uiState = MutableStateFlow(TimelineUiState())
     val uiState: StateFlow<TimelineUiState> = _uiState
 
     init {
-        scope.launch {
+        viewModelScope.launch {
             runCatching { repository.getArticles() }
                 .onSuccess { articles ->
                     _uiState.value = TimelineUiState(articles = articles, isLoading = false)

--- a/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
@@ -12,9 +12,13 @@ import com.hopescrolling.data.rss.Article
 import com.hopescrolling.ui.screens.TimelineViewModel
 import com.hopescrolling.util.FakeArticleRepository
 import com.hopescrolling.util.FakeFeedSourceRepository
-import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
@@ -45,7 +49,11 @@ class ScreenshotTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private fun viewModelScope() = TestScope(UnconfinedTestDispatcher())
+    @Before
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
 
     private fun saveScreenshot(name: String) {
         composeTestRule.waitForIdle()
@@ -68,7 +76,7 @@ class ScreenshotTest {
             Article(title = "Kotlin 2.2 Brings Improved Type Inference", link = "https://a.com/2", description = "The latest Kotlin release ships smarter type inference and faster incremental compilation.", pubDate = "Mon, 31 Mar 2026 14:30:00 GMT", feedSourceId = "kotlin"),
             Article(title = "Jetpack Compose Stability Update", link = "https://a.com/3", description = null, pubDate = "Sun, 30 Mar 2026 08:00:00 GMT", feedSourceId = "android"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), viewModelScope())
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
         saveScreenshot("timeline_screen")
         assertTrue(File(screenshotsDir, "timeline_screen.png").exists())
@@ -76,7 +84,7 @@ class ScreenshotTest {
 
     @Test
     fun screenshot_feedManagerScreen_empty() {
-        val viewModel = FeedManagerViewModel(FakeFeedSourceRepository(), viewModelScope())
+        val viewModel = FeedManagerViewModel(FakeFeedSourceRepository())
         composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
         saveScreenshot("feed_manager_empty")
         assertTrue(File(screenshotsDir, "feed_manager_empty.png").exists())
@@ -89,7 +97,7 @@ class ScreenshotTest {
             FeedSource(id = "1", name = "Tech Blog", url = "https://tech.example.com/feed"),
             FeedSource(id = "2", name = "News Feed", url = "https://news.example.com/feed"),
         )
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
         composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
         saveScreenshot("feed_manager_with_feeds")
         assertTrue(File(screenshotsDir, "feed_manager_with_feeds.png").exists())

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerScreenTest.kt
@@ -13,9 +13,12 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.AnnotatedString
 import com.hopescrolling.data.feed.FeedSource
 import com.hopescrolling.util.FakeFeedSourceRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,7 +31,11 @@ class FeedManagerScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private fun viewModelScope(): CoroutineScope = TestScope(UnconfinedTestDispatcher())
+    @Before
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
 
     @Test
     fun feedManagerScreen_showsFeedSourceNames() {
@@ -37,7 +44,7 @@ class FeedManagerScreenTest {
             FeedSource(id = "1", name = "Tech Blog", url = "https://tech.example.com/feed"),
             FeedSource(id = "2", name = "News Feed", url = "https://news.example.com/feed"),
         )
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
         composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("Tech Blog").assertIsDisplayed()
@@ -46,7 +53,7 @@ class FeedManagerScreenTest {
 
     @Test
     fun feedManagerScreen_hasAddInputAndButton() {
-        val viewModel = FeedManagerViewModel(FakeFeedSourceRepository(), viewModelScope())
+        val viewModel = FeedManagerViewModel(FakeFeedSourceRepository())
         composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("add_feed_input").assertIsDisplayed()
@@ -56,7 +63,7 @@ class FeedManagerScreenTest {
     @Test
     fun feedManagerScreen_addingUrlAppearsInList() {
         val repo = FakeFeedSourceRepository()
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
         composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("add_feed_input").performTextInput("https://example.com/rss")
@@ -71,7 +78,7 @@ class FeedManagerScreenTest {
         repo.sources.value = listOf(
             FeedSource(id = "1", name = "Tech Blog", url = "https://tech.example.com/feed"),
         )
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
         composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("delete_feed_1").performClick()
@@ -85,7 +92,7 @@ class FeedManagerScreenTest {
         repo.sources.value = listOf(
             FeedSource(id = "1", name = "Old Name", url = "https://example.com/feed"),
         )
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
         composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("rename_feed_1").performClick()

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/FeedManagerViewModelTest.kt
@@ -2,24 +2,32 @@ package com.hopescrolling.ui.screens
 
 import com.hopescrolling.data.feed.FeedSource
 import com.hopescrolling.util.FakeFeedSourceRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class FeedManagerViewModelTest {
 
-    private fun viewModelScope() = TestScope(UnconfinedTestDispatcher())
+    @Before
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
 
     @Test
     fun `renameFeed updates the name of the source with the given id`() = runTest {
         val repo = FakeFeedSourceRepository()
         val source = FeedSource(id = "1", name = "Old Name", url = "https://example.com/feed")
         repo.add(source)
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
 
         viewModel.renameFeed("1", "New Name")
 
@@ -33,7 +41,7 @@ class FeedManagerViewModelTest {
         val repo = FakeFeedSourceRepository()
         val source = FeedSource(id = "1", name = "Feed", url = "https://example.com/feed")
         repo.add(source)
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
 
         viewModel.deleteFeed("1")
 
@@ -43,7 +51,7 @@ class FeedManagerViewModelTest {
     @Test
     fun `addFeed adds a source with the given url`() = runTest {
         val repo = FakeFeedSourceRepository()
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
 
         viewModel.addFeed("https://example.com/feed")
 
@@ -57,7 +65,7 @@ class FeedManagerViewModelTest {
         val repo = FakeFeedSourceRepository()
         val source = FeedSource(id = "1", name = "Test Feed", url = "https://example.com/feed")
         repo.add(source)
-        val viewModel = FeedManagerViewModel(repo, viewModelScope())
+        val viewModel = FeedManagerViewModel(repo)
 
         assertEquals(listOf(source), viewModel.feedSources.first())
     }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
@@ -6,10 +6,13 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.hopescrolling.data.rss.Article
 import com.hopescrolling.util.FakeArticleRepository
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,13 +25,18 @@ class TimelineScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private fun viewModelScope(): CoroutineScope = TestScope(UnconfinedTestDispatcher())
+    @Before
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
 
     @Test
     fun timelineScreen_showsLoadingIndicatorWhileLoading() {
         val dispatcher = StandardTestDispatcher()
+        Dispatchers.setMain(dispatcher)
         val repo = FakeArticleRepository()
-        val viewModel = TimelineViewModel(repo, TestScope(dispatcher))
+        val viewModel = TimelineViewModel(repo)
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_loading").assertIsDisplayed()
@@ -40,7 +48,7 @@ class TimelineScreenTest {
             Article(title = "First Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
             Article(title = "Second Post", link = "https://a.com/2", description = null, pubDate = null, feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), viewModelScope())
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("First Post").assertIsDisplayed()
@@ -52,7 +60,7 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Post With Desc", link = "https://a.com/1", description = "A summary of the post", pubDate = null, feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), viewModelScope())
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("A summary of the post").assertIsDisplayed()
@@ -61,7 +69,7 @@ class TimelineScreenTest {
     @Test
     fun timelineScreen_showsErrorMessage() {
         val repo = FakeArticleRepository(error = RuntimeException("could not load"))
-        val viewModel = TimelineViewModel(repo, viewModelScope())
+        val viewModel = TimelineViewModel(repo)
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_error").assertIsDisplayed()
@@ -70,7 +78,7 @@ class TimelineScreenTest {
 
     @Test
     fun timelineScreen_showsEmptyStateWhenNoArticles() {
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = emptyList()), viewModelScope())
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = emptyList()))
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_empty").assertIsDisplayed()

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
@@ -2,24 +2,33 @@ package com.hopescrolling.ui.screens
 
 import com.hopescrolling.data.rss.Article
 import com.hopescrolling.util.FakeArticleRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class TimelineViewModelTest {
 
-    private fun viewModelScope() = TestScope(UnconfinedTestDispatcher())
+    @Before
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
 
     @Test
     fun `uiState initially has isLoading true`() {
         val dispatcher = StandardTestDispatcher()
+        Dispatchers.setMain(dispatcher)
         val repo = FakeArticleRepository()
-        val viewModel = TimelineViewModel(repo, TestScope(dispatcher))
+        val viewModel = TimelineViewModel(repo)
 
         assertEquals(true, viewModel.uiState.value.isLoading)
     }
@@ -31,7 +40,7 @@ class TimelineViewModelTest {
             Article(title = "Second", link = "https://a.com/2", description = null, pubDate = null, feedSourceId = "f1"),
         )
         val repo = FakeArticleRepository(articles = articles)
-        val viewModel = TimelineViewModel(repo, viewModelScope())
+        val viewModel = TimelineViewModel(repo)
 
         val state = viewModel.uiState.first { !it.isLoading }
 
@@ -42,7 +51,7 @@ class TimelineViewModelTest {
     @Test
     fun `uiState emits error and isLoading false when repository throws`() = runTest {
         val repo = FakeArticleRepository(error = RuntimeException("network failure"))
-        val viewModel = TimelineViewModel(repo, viewModelScope())
+        val viewModel = TimelineViewModel(repo)
 
         val state = viewModel.uiState.first { !it.isLoading }
 
@@ -53,7 +62,7 @@ class TimelineViewModelTest {
     @Test
     fun `uiState emits non-null error when exception has no message`() = runTest {
         val repo = FakeArticleRepository(error = RuntimeException())
-        val viewModel = TimelineViewModel(repo, viewModelScope())
+        val viewModel = TimelineViewModel(repo)
 
         val state = viewModel.uiState.first { !it.isLoading }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitExt" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 


### PR DESCRIPTION
## Summary
- `TimelineViewModel` and `FeedManagerViewModel` now extend `androidx.lifecycle.ViewModel` and use `viewModelScope` instead of an injected `CoroutineScope`
- `AppNavigation` uses `viewModel { ... }` inside each `composable {}` block so each ViewModel is scoped to its back-stack entry and survives configuration changes
- Adds `lifecycle-viewmodel-ktx` and `lifecycle-viewmodel-compose` dependencies
- Tests updated to use `Dispatchers.setMain`/`resetMain` in `@Before`/`@After`

## Test plan
- [ ] All unit tests pass
- [ ] ViewModel state persists across configuration changes (rotation)
- [ ] ViewModel is not re-created when navigating between screens

Closes #21