### PR TITLE
[#8] feat: complete ArticleCard — source name, pub date, tap-to-open-browser

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/data/article/DefaultArticleRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/DefaultArticleRepository.kt
@@ -17,7 +17,14 @@ class DefaultArticleRepository(
 ) : ArticleRepository {
     override suspend fun getArticles(): List<Article> = coroutineScope {
         feedSourceRepository.getAll().first()
-            .map { source -> async { runCatching { fetcher.fetch(source.url).let { RssParser.parse(it, source.id) } }.getOrElse { emptyList() } } }
+            .map { source ->
+                async {
+                    runCatching {
+                        RssParser.parse(fetcher.fetch(source.url), source.id)
+                            .map { it.copy(sourceName = source.name) }
+                    }.getOrElse { emptyList() }
+                }
+            }
             .awaitAll()
             .flatten()
             .sortedByDescending { parsePubDate(it.pubDate) }

--- a/app/src/main/kotlin/com/hopescrolling/data/rss/Article.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/rss/Article.kt
@@ -5,5 +5,6 @@ data class Article(
     val link: String,
     val description: String?,
     val pubDate: String?,
-    val feedSourceId: String
+    val feedSourceId: String,
+    val sourceName: String = "",
 )

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
@@ -1,5 +1,8 @@
 package com.hopescrolling.ui.screens
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +17,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.hopescrolling.data.rss.Article
@@ -60,7 +64,17 @@ private fun CenteredFullScreen(content: @Composable () -> Unit) {
 
 @Composable
 fun ArticleCard(article: Article, index: Int) {
+    val context = LocalContext.current
     Card(
+        onClick = {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(article.link))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            try {
+                context.startActivity(intent)
+            } catch (_: ActivityNotFoundException) {
+                // No browser available — ignore
+            }
+        },
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -68,12 +82,18 @@ fun ArticleCard(article: Article, index: Int) {
     ) {
         Text(
             text = article.title,
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
         )
         if (article.description != null) {
             Text(
                 text = article.description,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        if (article.sourceName.isNotEmpty() || article.pubDate != null) {
+            Text(
+                text = listOfNotNull(article.sourceName.takeIf { it.isNotEmpty() }, article.pubDate).joinToString(" · "),
+                modifier = Modifier.padding(start = 16.dp, bottom = 16.dp, end = 16.dp),
             )
         }
     }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
@@ -1,6 +1,7 @@
 package com.hopescrolling.ui.screens
 
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -97,5 +98,62 @@ class TimelineScreenTest {
 
         composeTestRule.onNodeWithText("No Desc Post").assertIsDisplayed()
         composeTestRule.onAllNodesWithText(descriptionText).assertCountEquals(0)
+    }
+
+    @Test
+    fun timelineScreen_showsSourceName() {
+        val articles = listOf(
+            Article(title = "Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1", sourceName = "Tech Blog"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithText("Tech Blog").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsPubDate() {
+        val articles = listOf(
+            Article(title = "Post", link = "https://a.com/1", description = null, pubDate = "Mon, 01 Jan 2026 12:00:00 GMT", feedSourceId = "f1"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithText("Mon, 01 Jan 2026 12:00:00 GMT").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_articleCardIsClickable() {
+        val articles = listOf(
+            Article(title = "Clickable Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("article_card_0").assertHasClickAction()
+    }
+
+    @Test
+    fun timelineScreen_showsSourceNameAndPubDateCombined() {
+        val articles = listOf(
+            Article(title = "Post", link = "https://a.com/1", description = null, pubDate = "Mon, 01 Jan 2026 12:00:00 GMT", feedSourceId = "f1", sourceName = "Tech Blog"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithText("Tech Blog · Mon, 01 Jan 2026 12:00:00 GMT").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_noMetadataWhenSourceNameEmptyAndNoPubDate() {
+        val articles = listOf(
+            Article(title = "Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        // Only the title text is present; no metadata row
+        composeTestRule.onNodeWithText("Post").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(" · ").assertCountEquals(0)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `sourceName: String = ""` to `Article`; `DefaultArticleRepository` populates it from the feed source name
- `ArticleCard` shows source name and raw pub date in a footer line (`"source · date"`)
- `ArticleCard` is now clickable: opens `article.link` in the browser via `Intent.ACTION_VIEW`
- `FLAG_ACTIVITY_NEW_TASK` added and `ActivityNotFoundException` caught to handle edge cases safely
- Tests: source name display, pub date display, combined footer, footer absent when both empty/null, click action

## Out of scope (tracked)
- #34: Format pub date as human-readable string

Closes #8