### PR TITLE
[#25] feat: add refresh() to TimelineViewModel and retry button on error

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
@@ -4,11 +4,13 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
@@ -36,7 +38,15 @@ fun TimelineScreen(viewModel: TimelineViewModel) {
                 CircularProgressIndicator(modifier = Modifier.testTag("timeline_loading"))
             }
             uiState.error != null -> CenteredFullScreen {
-                Text(text = uiState.error!!, modifier = Modifier.testTag("timeline_error"))
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(text = uiState.error!!, modifier = Modifier.testTag("timeline_error"))
+                    Button(
+                        onClick = { viewModel.refresh() },
+                        modifier = Modifier.testTag("timeline_retry"),
+                    ) {
+                        Text("Retry")
+                    }
+                }
             }
             uiState.articles.isEmpty() -> CenteredFullScreen {
                 Text(

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hopescrolling.data.article.ArticleRepository
 import com.hopescrolling.data.rss.Article
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -19,9 +20,16 @@ class TimelineViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TimelineUiState())
     val uiState: StateFlow<TimelineUiState> = _uiState
+    private var fetchJob: Job? = null
 
     init {
-        viewModelScope.launch {
+        refresh()
+    }
+
+    fun refresh() {
+        fetchJob?.cancel()
+        _uiState.value = TimelineUiState(isLoading = true)
+        fetchJob = viewModelScope.launch {
             runCatching { repository.getArticles() }
                 .onSuccess { articles ->
                     _uiState.value = TimelineUiState(articles = articles, isLoading = false)

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
@@ -7,6 +7,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.hopescrolling.data.article.ArticleRepository
+import java.util.concurrent.atomic.AtomicBoolean
 import com.hopescrolling.data.rss.Article
 import com.hopescrolling.util.FakeArticleRepository
 import kotlinx.coroutines.Dispatchers
@@ -142,6 +145,38 @@ class TimelineScreenTest {
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("Tech Blog · Mon, 01 Jan 2026 12:00:00 GMT").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsRetryButtonOnError() {
+        val repo = FakeArticleRepository(error = RuntimeException("fetch failed"))
+        val viewModel = TimelineViewModel(repo)
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("timeline_retry").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("timeline_retry").assertHasClickAction()
+    }
+
+    @Test
+    fun timelineScreen_retryButtonTriggersRefetchAndShowsArticles() {
+        val articles = listOf(
+            Article(title = "After Retry", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val shouldFail = AtomicBoolean(true)
+        val repo = object : ArticleRepository {
+            override suspend fun getArticles(): List<Article> {
+                if (shouldFail.get()) throw RuntimeException("fail")
+                return articles
+            }
+        }
+        val viewModel = TimelineViewModel(repo)
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("timeline_retry").assertIsDisplayed()
+        shouldFail.set(false)
+        composeTestRule.onNodeWithTag("timeline_retry").performClick()
+
+        composeTestRule.onNodeWithText("After Retry").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
@@ -68,4 +68,39 @@ class TimelineViewModelTest {
 
         assertEquals(false, state.error.isNullOrBlank())
     }
+
+    @Test
+    fun `refresh resets state to loading while fetching`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            val repo = FakeArticleRepository()
+            val viewModel = TimelineViewModel(repo)
+            testScheduler.advanceUntilIdle() // complete init fetch
+
+            viewModel.refresh()
+
+            assertEquals(true, viewModel.uiState.value.isLoading)
+            assertEquals(null, viewModel.uiState.value.error)
+        } finally {
+            Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        }
+    }
+
+    @Test
+    fun `refresh re-fetches and emits articles`() = runTest {
+        val articles = listOf(
+            Article(title = "Refreshed", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val repo = FakeArticleRepository(articles = articles)
+        val viewModel = TimelineViewModel(repo)
+        viewModel.uiState.first { !it.isLoading } // wait for init
+        val countBeforeRefresh = repo.callCount
+
+        viewModel.refresh()
+        viewModel.uiState.first { !it.isLoading }
+
+        assertEquals(countBeforeRefresh + 1, repo.callCount)
+        assertEquals(articles, viewModel.uiState.value.articles)
+    }
 }

--- a/app/src/test/kotlin/com/hopescrolling/util/FakeArticleRepository.kt
+++ b/app/src/test/kotlin/com/hopescrolling/util/FakeArticleRepository.kt
@@ -7,7 +7,11 @@ class FakeArticleRepository(
     private val articles: List<Article> = emptyList(),
     private val error: Throwable? = null,
 ) : ArticleRepository {
+    var callCount = 0
+        private set
+
     override suspend fun getArticles(): List<Article> {
+        callCount++
         if (error != null) throw error
         return articles
     }


### PR DESCRIPTION
Extracts the fetch logic from `init` into a public `refresh()` method that cancels any in-flight fetch, resets state to loading, and re-triggers `repository.getArticles()`. The error state in `TimelineScreen` now shows a Retry button that invokes `refresh()`.

Closes #25