### PR TITLE
[#9] feat: add ReadStateRepository with Room, wire read tracking into timeline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -79,6 +80,9 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/kotlin/com/hopescrolling/data/readstate/AppDatabase.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/readstate/AppDatabase.kt
@@ -1,0 +1,9 @@
+package com.hopescrolling.data.readstate
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [ReadArticleEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun readArticleDao(): ReadArticleDao
+}

--- a/app/src/main/kotlin/com/hopescrolling/data/readstate/ReadArticleDao.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/readstate/ReadArticleDao.kt
@@ -1,0 +1,16 @@
+package com.hopescrolling.data.readstate
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ReadArticleDao {
+    @Query("SELECT id FROM read_articles")
+    fun getAllIds(): Flow<List<String>>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(entity: ReadArticleEntity)
+}

--- a/app/src/main/kotlin/com/hopescrolling/data/readstate/ReadArticleEntity.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/readstate/ReadArticleEntity.kt
@@ -1,0 +1,9 @@
+package com.hopescrolling.data.readstate
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "read_articles")
+data class ReadArticleEntity(
+    @PrimaryKey val id: String,
+)

--- a/app/src/main/kotlin/com/hopescrolling/data/readstate/ReadStateRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/readstate/ReadStateRepository.kt
@@ -1,0 +1,8 @@
+package com.hopescrolling.data.readstate
+
+import kotlinx.coroutines.flow.Flow
+
+interface ReadStateRepository {
+    fun getReadIds(): Flow<Set<String>>
+    suspend fun markRead(articleId: String)
+}

--- a/app/src/main/kotlin/com/hopescrolling/data/readstate/RoomReadStateRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/readstate/RoomReadStateRepository.kt
@@ -1,0 +1,12 @@
+package com.hopescrolling.data.readstate
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class RoomReadStateRepository(private val dao: ReadArticleDao) : ReadStateRepository {
+    override fun getReadIds(): Flow<Set<String>> = dao.getAllIds().map { it.toSet() }
+
+    override suspend fun markRead(articleId: String) {
+        dao.insert(ReadArticleEntity(id = articleId))
+    }
+}

--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -20,10 +20,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.room.Room
 import com.hopescrolling.data.article.DefaultArticleRepository
 import com.hopescrolling.data.article.httpRssFeedFetcher
 import com.hopescrolling.data.feed.DataStoreFeedSourceRepository
 import com.hopescrolling.data.feed.feedSourceDataStore
+import com.hopescrolling.data.readstate.AppDatabase
+import com.hopescrolling.data.readstate.RoomReadStateRepository
 import com.hopescrolling.ui.screens.FeedManagerScreen
 import com.hopescrolling.ui.screens.FeedManagerViewModel
 import com.hopescrolling.ui.screens.TimelineScreen
@@ -39,6 +42,12 @@ fun AppNavigation() {
     val feedSourceRepository = remember { DataStoreFeedSourceRepository(context.feedSourceDataStore) }
     val rssFeedFetcher = remember { httpRssFeedFetcher() }
     val articleRepository = remember { DefaultArticleRepository(feedSourceRepository, rssFeedFetcher) }
+    val db = remember {
+        Room.databaseBuilder(context, AppDatabase::class.java, "hopescrolling-db")
+            .fallbackToDestructiveMigration()
+            .build()
+    }
+    val readStateRepository = remember(db) { RoomReadStateRepository(db.readArticleDao()) }
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
@@ -76,7 +85,7 @@ fun AppNavigation() {
             modifier = Modifier.padding(padding),
         ) {
             composable(ROUTE_TIMELINE) {
-                val viewModel = viewModel { TimelineViewModel(articleRepository) }
+                val viewModel = viewModel { TimelineViewModel(articleRepository, readStateRepository) }
                 TimelineScreen(viewModel)
             }
             composable(ROUTE_FEED_MANAGER) {

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -56,7 +57,12 @@ fun TimelineScreen(viewModel: TimelineViewModel) {
             }
             else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
                 itemsIndexed(uiState.articles) { index, article ->
-                    ArticleCard(article = article, index = index)
+                    ArticleCard(
+                        article = article,
+                        index = index,
+                        isRead = uiState.readIds.contains(article.link),
+                        onRead = { viewModel.markRead(article.link) },
+                    )
                 }
             }
         }
@@ -73,10 +79,11 @@ private fun CenteredFullScreen(content: @Composable () -> Unit) {
 }
 
 @Composable
-fun ArticleCard(article: Article, index: Int) {
+fun ArticleCard(article: Article, index: Int, isRead: Boolean, onRead: () -> Unit) {
     val context = LocalContext.current
     Card(
         onClick = {
+            onRead()
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(article.link))
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             try {
@@ -88,7 +95,8 @@ fun ArticleCard(article: Article, index: Int) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp)
-            .testTag("article_card_$index"),
+            .testTag("article_card_$index")
+            .alpha(if (isRead) 0.5f else 1.0f),
     ) {
         Text(
             text = article.title,

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
@@ -3,40 +3,55 @@ package com.hopescrolling.ui.screens
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hopescrolling.data.article.ArticleRepository
+import com.hopescrolling.data.readstate.ReadStateRepository
 import com.hopescrolling.data.rss.Article
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class TimelineUiState(
     val articles: List<Article> = emptyList(),
     val isLoading: Boolean = true,
     val error: String? = null,
+    val readIds: Set<String> = emptySet(),
 )
 
 class TimelineViewModel(
     private val repository: ArticleRepository,
+    private val readStateRepository: ReadStateRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TimelineUiState())
     val uiState: StateFlow<TimelineUiState> = _uiState
     private var fetchJob: Job? = null
 
     init {
+        viewModelScope.launch {
+            readStateRepository.getReadIds().collect { readIds ->
+                _uiState.update { it.copy(readIds = readIds) }
+            }
+        }
         refresh()
     }
 
     fun refresh() {
         fetchJob?.cancel()
-        _uiState.value = TimelineUiState(isLoading = true)
+        _uiState.update { it.copy(isLoading = true, error = null) }
         fetchJob = viewModelScope.launch {
             runCatching { repository.getArticles() }
                 .onSuccess { articles ->
-                    _uiState.value = TimelineUiState(articles = articles, isLoading = false)
+                    _uiState.update { it.copy(articles = articles, isLoading = false) }
                 }
                 .onFailure { e ->
-                    _uiState.value = TimelineUiState(isLoading = false, error = e.message ?: e::class.simpleName ?: "Unknown error")
+                    _uiState.update { it.copy(isLoading = false, error = e.message ?: e::class.simpleName ?: "Unknown error") }
                 }
+        }
+    }
+
+    fun markRead(articleId: String) {
+        viewModelScope.launch {
+            readStateRepository.markRead(articleId)
         }
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
@@ -12,6 +12,7 @@ import com.hopescrolling.data.rss.Article
 import com.hopescrolling.ui.screens.TimelineViewModel
 import com.hopescrolling.util.FakeArticleRepository
 import com.hopescrolling.util.FakeFeedSourceRepository
+import com.hopescrolling.util.FakeReadStateRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -76,10 +77,24 @@ class ScreenshotTest {
             Article(title = "Kotlin 2.2 Brings Improved Type Inference", link = "https://a.com/2", description = "The latest Kotlin release ships smarter type inference and faster incremental compilation.", pubDate = "Mon, 31 Mar 2026 14:30:00 GMT", feedSourceId = "kotlin"),
             Article(title = "Jetpack Compose Stability Update", link = "https://a.com/3", description = null, pubDate = "Sun, 30 Mar 2026 08:00:00 GMT", feedSourceId = "android"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
         saveScreenshot("timeline_screen")
         assertTrue(File(screenshotsDir, "timeline_screen.png").exists())
+    }
+
+    @Test
+    fun screenshot_timelineScreen_withReadArticle() {
+        val articles = listOf(
+            Article(title = "Already Read Article", link = "https://a.com/1", description = "This article has been read and should appear dimmed.", pubDate = "Tue, 01 Apr 2026 09:00:00 GMT", feedSourceId = "android"),
+            Article(title = "Unread Article", link = "https://a.com/2", description = "This article has not been read yet.", pubDate = "Mon, 31 Mar 2026 14:30:00 GMT", feedSourceId = "kotlin"),
+        )
+        val readStateRepo = FakeReadStateRepository()
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), readStateRepo)
+        viewModel.markRead("https://a.com/1")
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+        saveScreenshot("timeline_screen_read_state")
+        assertTrue(File(screenshotsDir, "timeline_screen_read_state.png").exists())
     }
 
     @Test

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
@@ -12,6 +12,8 @@ import com.hopescrolling.data.article.ArticleRepository
 import java.util.concurrent.atomic.AtomicBoolean
 import com.hopescrolling.data.rss.Article
 import com.hopescrolling.util.FakeArticleRepository
+import com.hopescrolling.util.FakeReadStateRepository
+import org.junit.Assert.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -42,7 +44,7 @@ class TimelineScreenTest {
         val dispatcher = StandardTestDispatcher()
         Dispatchers.setMain(dispatcher)
         val repo = FakeArticleRepository()
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_loading").assertIsDisplayed()
@@ -54,7 +56,7 @@ class TimelineScreenTest {
             Article(title = "First Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
             Article(title = "Second Post", link = "https://a.com/2", description = null, pubDate = null, feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("First Post").assertIsDisplayed()
@@ -66,7 +68,7 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Post With Desc", link = "https://a.com/1", description = "A summary of the post", pubDate = null, feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("A summary of the post").assertIsDisplayed()
@@ -75,7 +77,7 @@ class TimelineScreenTest {
     @Test
     fun timelineScreen_showsErrorMessage() {
         val repo = FakeArticleRepository(error = RuntimeException("could not load"))
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_error").assertIsDisplayed()
@@ -84,7 +86,7 @@ class TimelineScreenTest {
 
     @Test
     fun timelineScreen_showsEmptyStateWhenNoArticles() {
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = emptyList()))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = emptyList()), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_empty").assertIsDisplayed()
@@ -96,7 +98,7 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "No Desc Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("No Desc Post").assertIsDisplayed()
@@ -108,7 +110,7 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1", sourceName = "Tech Blog"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("Tech Blog").assertIsDisplayed()
@@ -119,7 +121,7 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Post", link = "https://a.com/1", description = null, pubDate = "Mon, 01 Jan 2026 12:00:00 GMT", feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("Mon, 01 Jan 2026 12:00:00 GMT").assertIsDisplayed()
@@ -130,7 +132,7 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Clickable Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("article_card_0").assertHasClickAction()
@@ -141,7 +143,7 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Post", link = "https://a.com/1", description = null, pubDate = "Mon, 01 Jan 2026 12:00:00 GMT", feedSourceId = "f1", sourceName = "Tech Blog"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithText("Tech Blog · Mon, 01 Jan 2026 12:00:00 GMT").assertIsDisplayed()
@@ -150,7 +152,7 @@ class TimelineScreenTest {
     @Test
     fun timelineScreen_showsRetryButtonOnError() {
         val repo = FakeArticleRepository(error = RuntimeException("fetch failed"))
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_retry").assertIsDisplayed()
@@ -169,7 +171,7 @@ class TimelineScreenTest {
                 return articles
             }
         }
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("timeline_retry").assertIsDisplayed()
@@ -184,11 +186,25 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
         )
-        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles))
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
 
         // Only the title text is present; no metadata row
         composeTestRule.onNodeWithText("Post").assertIsDisplayed()
         composeTestRule.onAllNodesWithText(" · ").assertCountEquals(0)
+    }
+
+    @Test
+    fun timelineScreen_tappingArticleCardCallsMarkRead() {
+        val articles = listOf(
+            Article(title = "Tap Me", link = "https://a.com/tap", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val readStateRepo = FakeReadStateRepository()
+        val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), readStateRepo)
+        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("article_card_0").performClick()
+
+        assertEquals(setOf("https://a.com/tap"), viewModel.uiState.value.readIds)
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
@@ -2,6 +2,7 @@ package com.hopescrolling.ui.screens
 
 import com.hopescrolling.data.rss.Article
 import com.hopescrolling.util.FakeArticleRepository
+import com.hopescrolling.util.FakeReadStateRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -28,7 +29,7 @@ class TimelineViewModelTest {
         val dispatcher = StandardTestDispatcher()
         Dispatchers.setMain(dispatcher)
         val repo = FakeArticleRepository()
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
 
         assertEquals(true, viewModel.uiState.value.isLoading)
     }
@@ -40,7 +41,7 @@ class TimelineViewModelTest {
             Article(title = "Second", link = "https://a.com/2", description = null, pubDate = null, feedSourceId = "f1"),
         )
         val repo = FakeArticleRepository(articles = articles)
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
 
         val state = viewModel.uiState.first { !it.isLoading }
 
@@ -51,7 +52,7 @@ class TimelineViewModelTest {
     @Test
     fun `uiState emits error and isLoading false when repository throws`() = runTest {
         val repo = FakeArticleRepository(error = RuntimeException("network failure"))
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
 
         val state = viewModel.uiState.first { !it.isLoading }
 
@@ -62,7 +63,7 @@ class TimelineViewModelTest {
     @Test
     fun `uiState emits non-null error when exception has no message`() = runTest {
         val repo = FakeArticleRepository(error = RuntimeException())
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
 
         val state = viewModel.uiState.first { !it.isLoading }
 
@@ -75,7 +76,7 @@ class TimelineViewModelTest {
         Dispatchers.setMain(testDispatcher)
         try {
             val repo = FakeArticleRepository()
-            val viewModel = TimelineViewModel(repo)
+            val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
             testScheduler.advanceUntilIdle() // complete init fetch
 
             viewModel.refresh()
@@ -93,7 +94,7 @@ class TimelineViewModelTest {
             Article(title = "Refreshed", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
         )
         val repo = FakeArticleRepository(articles = articles)
-        val viewModel = TimelineViewModel(repo)
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
         viewModel.uiState.first { !it.isLoading } // wait for init
         val countBeforeRefresh = repo.callCount
 
@@ -102,5 +103,23 @@ class TimelineViewModelTest {
 
         assertEquals(countBeforeRefresh + 1, repo.callCount)
         assertEquals(articles, viewModel.uiState.value.articles)
+    }
+
+    @Test
+    fun `uiState readIds is empty when no articles have been read`() = runTest {
+        val viewModel = TimelineViewModel(FakeArticleRepository(), FakeReadStateRepository())
+
+        val state = viewModel.uiState.first()
+
+        assertEquals(emptySet<String>(), state.readIds)
+    }
+
+    @Test
+    fun `markRead adds article id to uiState readIds`() = runTest {
+        val viewModel = TimelineViewModel(FakeArticleRepository(), FakeReadStateRepository())
+
+        viewModel.markRead("https://a.com/1")
+
+        assertEquals(setOf("https://a.com/1"), viewModel.uiState.value.readIds)
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/util/FakeReadStateRepository.kt
+++ b/app/src/test/kotlin/com/hopescrolling/util/FakeReadStateRepository.kt
@@ -1,0 +1,16 @@
+package com.hopescrolling.util
+
+import com.hopescrolling.data.readstate.ReadStateRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+class FakeReadStateRepository : ReadStateRepository {
+    private val readIds = MutableStateFlow<Set<String>>(emptySet())
+
+    override fun getReadIds(): Flow<Set<String>> = readIds
+
+    override suspend fun markRead(articleId: String) {
+        readIds.value = readIds.value + articleId
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ espressoCore = "3.6.1"
 datastore = "1.1.1"
 kotlinx-coroutines = "1.9.0"
 robolectric = "4.14.1"
+room = "2.6.1"
+ksp = "2.1.0-1.0.29"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,8 +36,12 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
Implements `ReadStateRepository` backed by Room to track which articles have been opened. Tapping an article card fires `markRead()`, persisting the article link to the Room database. Read articles render at 0.5 alpha in `ArticleCard`. `TimelineViewModel` collects read IDs as a `Flow<Set<String>>` into `uiState.readIds`.

Closes #9