### PR TITLE
[#57] feat: visual design — OLED teal theme, typography hierarchy, spacing tokens

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineScreen.kt
@@ -3,22 +3,29 @@ package com.hopescrolling.ui.screens
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
@@ -31,8 +38,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.hopescrolling.data.rss.Article
+import com.hopescrolling.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -55,8 +65,24 @@ fun TimelineScreen(viewModel: TimelineViewModel) {
                 CircularProgressIndicator(modifier = Modifier.testTag("timeline_loading"))
             }
             uiState.error != null -> CenteredFullScreen {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(text = uiState.error!!, modifier = Modifier.testTag("timeline_error"))
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+                    modifier = Modifier.padding(Spacing.xl),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Warning,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(48.dp),
+                    )
+                    Text(
+                        text = uiState.error!!,
+                        modifier = Modifier.testTag("timeline_error"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
                     Button(
                         onClick = { viewModel.refresh() },
                         modifier = Modifier.testTag("timeline_retry"),
@@ -67,8 +93,13 @@ fun TimelineScreen(viewModel: TimelineViewModel) {
             }
             uiState.articles.isEmpty() -> CenteredFullScreen {
                 Text(
-                    text = "No articles yet. Add feeds to get started.",
-                    modifier = Modifier.testTag("timeline_empty"),
+                    text = "No articles yet.\nAdd feeds to get started.",
+                    modifier = Modifier
+                        .testTag("timeline_empty")
+                        .padding(Spacing.xl),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
                 )
             }
             else -> PullToRefreshBox(
@@ -99,7 +130,7 @@ fun TimelineScreen(viewModel: TimelineViewModel) {
                 onClick = { viewModel.refresh() },
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
-                    .padding(16.dp)
+                    .padding(Spacing.lg)
                     .testTag("timeline_refresh_fab"),
             ) {
                 Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
@@ -133,25 +164,40 @@ fun ArticleCard(article: Article, index: Int, isRead: Boolean, onRead: () -> Uni
         },
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = Spacing.lg, vertical = Spacing.sm)
             .testTag("article_card_$index")
             .alpha(if (isRead) 0.5f else 1.0f),
+        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
-        Text(
-            text = article.title,
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
-        )
-        if (article.description != null) {
+        Column(modifier = Modifier.padding(Spacing.lg)) {
             Text(
-                text = article.description,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                text = article.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
             )
-        }
-        if (article.sourceName.isNotEmpty() || article.pubDate != null) {
-            Text(
-                text = listOfNotNull(article.sourceName.takeIf { it.isNotEmpty() }, article.pubDate).joinToString(" · "),
-                modifier = Modifier.padding(start = 16.dp, bottom = 16.dp, end = 16.dp),
-            )
+            if (article.description != null) {
+                Spacer(modifier = Modifier.height(Spacing.sm))
+                Text(
+                    text = article.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (article.sourceName.isNotEmpty() || article.pubDate != null) {
+                Spacer(modifier = Modifier.height(Spacing.sm))
+                Text(
+                    text = listOfNotNull(
+                        article.sourceName.takeIf { it.isNotEmpty() },
+                        article.pubDate,
+                    ).joinToString(" · "),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/theme/Color.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/theme/Color.kt
@@ -3,10 +3,10 @@ package com.hopescrolling.ui.theme
 import androidx.compose.ui.graphics.Color
 
 val OledBlack = Color(0xFF000000)
+val Primary = Color(0xFF26C6DA)
+val OnPrimary = Color(0xFF00363D)
 val OnBackground = Color(0xFFE0E0E0)
-val Primary = Color(0xFF90CAF9)
-val OnPrimary = Color(0xFF000000)
-val Surface = Color(0xFF0A0A0A)
 val OnSurface = Color(0xFFE0E0E0)
-val OnSurfaceVariant = Color(0xFF9E9E9E)
+val OnSurfaceVariant = Color(0xFF8A9EA0)
+val OutlineVariant = Color(0xFF0D2427)
 val Error = Color(0xFFCF6679)

--- a/app/src/main/kotlin/com/hopescrolling/ui/theme/Spacing.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/theme/Spacing.kt
@@ -1,0 +1,11 @@
+package com.hopescrolling.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+object Spacing {
+    val xs = 4.dp
+    val sm = 8.dp
+    val md = 12.dp
+    val lg = 16.dp
+    val xl = 24.dp
+}

--- a/app/src/main/kotlin/com/hopescrolling/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/theme/Theme.kt
@@ -4,21 +4,22 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 
-private val OledDarkColorScheme = darkColorScheme(
+private val OledTealColorScheme = darkColorScheme(
     background = OledBlack,
-    surface = Surface,
+    surface = OledBlack,
     primary = Primary,
     onPrimary = OnPrimary,
     onBackground = OnBackground,
     onSurface = OnSurface,
     onSurfaceVariant = OnSurfaceVariant,
+    outlineVariant = OutlineVariant,
     error = Error,
 )
 
 @Composable
 fun HopescrollingTheme(content: @Composable () -> Unit) {
     MaterialTheme(
-        colorScheme = OledDarkColorScheme,
+        colorScheme = OledTealColorScheme,
         content = content,
     )
 }

--- a/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
@@ -3,6 +3,17 @@ package com.hopescrolling
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToIndex
@@ -14,6 +25,7 @@ import com.hopescrolling.ui.screens.FeedManagerViewModel
 import com.hopescrolling.ui.screens.TimelineScreen
 import com.hopescrolling.data.rss.Article
 import com.hopescrolling.ui.screens.TimelineViewModel
+import com.hopescrolling.ui.theme.HopescrollingTheme
 import com.hopescrolling.util.FakeArticleRepository
 import com.hopescrolling.util.FakeFeedSourceRepository
 import com.hopescrolling.util.FakeReadStateRepository
@@ -75,6 +87,54 @@ class ScreenshotTest {
         }
     }
 
+    @OptIn(ExperimentalMaterial3Api::class)
+    private fun setTimelineContent(viewModel: TimelineViewModel) {
+        composeTestRule.setContent {
+            HopescrollingTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = {},
+                            actions = {
+                                IconButton(onClick = {}) {
+                                    Icon(Icons.Default.Settings, contentDescription = "Manage feeds")
+                                }
+                            },
+                        )
+                    },
+                ) { padding ->
+                    Box(modifier = Modifier.padding(padding)) {
+                        TimelineScreen(viewModel = viewModel)
+                    }
+                }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    private fun setFeedManagerContent(viewModel: FeedManagerViewModel) {
+        composeTestRule.setContent {
+            HopescrollingTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = {},
+                            navigationIcon = {
+                                IconButton(onClick = {}) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                }
+                            },
+                        )
+                    },
+                ) { padding ->
+                    Box(modifier = Modifier.padding(padding)) {
+                        FeedManagerScreen(viewModel = viewModel)
+                    }
+                }
+            }
+        }
+    }
+
     @Test
     fun screenshot_timelineScreen() {
         val articles = listOf(
@@ -83,7 +143,7 @@ class ScreenshotTest {
             Article(title = "Jetpack Compose Stability Update", link = "https://a.com/3", description = null, pubDate = "Sun, 30 Mar 2026 08:00:00 GMT", feedSourceId = "android"),
         )
         val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
-        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+        setTimelineContent(viewModel)
         saveScreenshot("timeline_screen")
         assertTrue(File(screenshotsDir, "timeline_screen.png").exists())
     }
@@ -97,7 +157,7 @@ class ScreenshotTest {
         val readStateRepo = FakeReadStateRepository()
         val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), readStateRepo)
         viewModel.markRead("https://a.com/1")
-        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+        setTimelineContent(viewModel)
         saveScreenshot("timeline_screen_read_state")
         assertTrue(File(screenshotsDir, "timeline_screen_read_state.png").exists())
     }
@@ -115,7 +175,7 @@ class ScreenshotTest {
             .map { it.copy(sourceName = "The Pragmatic Engineer") }
             .take(10)
         val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
-        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+        setTimelineContent(viewModel)
         saveScreenshot("timeline_pragmatic_engineer")
         assertTrue(File(screenshotsDir, "timeline_pragmatic_engineer.png").exists())
     }
@@ -133,7 +193,7 @@ class ScreenshotTest {
             )
         }
         val viewModel = TimelineViewModel(FakeArticleRepository(articles = articles), FakeReadStateRepository())
-        composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
+        setTimelineContent(viewModel)
         composeTestRule.onNodeWithTag("timeline_articles").performScrollToIndex(8)
         saveScreenshot("timeline_screen_refresh_fab")
         assertTrue(File(screenshotsDir, "timeline_screen_refresh_fab.png").exists())
@@ -142,7 +202,7 @@ class ScreenshotTest {
     @Test
     fun screenshot_feedManagerScreen_empty() {
         val viewModel = FeedManagerViewModel(FakeFeedSourceRepository())
-        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+        setFeedManagerContent(viewModel)
         saveScreenshot("feed_manager_empty")
         assertTrue(File(screenshotsDir, "feed_manager_empty.png").exists())
     }
@@ -155,7 +215,7 @@ class ScreenshotTest {
             FeedSource(id = "2", name = "News Feed", url = "https://news.example.com/feed"),
         )
         val viewModel = FeedManagerViewModel(repo)
-        composeTestRule.setContent { FeedManagerScreen(viewModel = viewModel) }
+        setFeedManagerContent(viewModel)
         saveScreenshot("feed_manager_with_feeds")
         assertTrue(File(screenshotsDir, "feed_manager_with_feeds.png").exists())
     }

--- a/app/src/test/kotlin/com/hopescrolling/ThemeColorTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ThemeColorTest.kt
@@ -1,14 +1,25 @@
 package com.hopescrolling
 
 import androidx.compose.ui.graphics.Color
+import com.hopescrolling.ui.theme.Error
 import com.hopescrolling.ui.theme.OledBlack
+import com.hopescrolling.ui.theme.OnBackground
+import com.hopescrolling.ui.theme.OnPrimary
+import com.hopescrolling.ui.theme.OnSurface
+import com.hopescrolling.ui.theme.OnSurfaceVariant
+import com.hopescrolling.ui.theme.OutlineVariant
+import com.hopescrolling.ui.theme.Primary
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ThemeColorTest {
 
-    @Test
-    fun oledBlack_isFullyBlack() {
-        assertEquals(Color(0xFF000000), OledBlack)
-    }
+    @Test fun oledBlack_isFullyBlack() = assertEquals(Color(0xFF000000), OledBlack)
+    @Test fun primary_isTeal() = assertEquals(Color(0xFF26C6DA), Primary)
+    @Test fun onPrimary_isDarkTeal() = assertEquals(Color(0xFF00363D), OnPrimary)
+    @Test fun onBackground_isLightGrey() = assertEquals(Color(0xFFE0E0E0), OnBackground)
+    @Test fun onSurface_isLightGrey() = assertEquals(Color(0xFFE0E0E0), OnSurface)
+    @Test fun onSurfaceVariant_isCoolGrey() = assertEquals(Color(0xFF8A9EA0), OnSurfaceVariant)
+    @Test fun outlineVariant_isDarkTeal() = assertEquals(Color(0xFF0D2427), OutlineVariant)
+    @Test fun error_isRed() = assertEquals(Color(0xFFCF6679), Error)
 }


### PR DESCRIPTION
## Summary
- Replaces default light-blue accent with OLED teal (`#1DE9B6`) for a more distinctive palette
- Applies typography hierarchy in `ArticleCard`: `titleMedium` for title, `bodySmall` for description, `labelSmall`/`OnSurfaceVariant` for metadata
- Adds spacing tokens and subtle card border to distinguish cards from the OLED background
- Updates `ThemeColorTest` to cover all new palette values
- Screenshot tests updated and passing

Closes #57