### PR TITLE
[#89] test: assert article element takes priority over role=main

### DIFF
--- a/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
@@ -94,6 +94,22 @@ class ArticleContentFetcherTest {
     }
 
     @Test
+    fun `article element takes priority over role=main`() = runTest {
+        val html = """
+            <html><body>
+                <div role="main"><p>Role main content</p></div>
+                <article><p>Article content</p></article>
+            </body></html>
+        """.trimIndent()
+        server.enqueue(MockResponse().setBody(html).setResponseCode(200))
+
+        val result = jsoupArticleContentFetcher().fetch(server.url("/").toString())
+
+        val content = result.getOrThrow()
+        assertEquals(listOf("Article content"), content.paragraphs)
+    }
+
+    @Test
     fun `extracts title and paragraphs from article element`() = runTest {
         val html = """
             <html><head><title>My Article</title></head>


### PR DESCRIPTION
## Summary

- Adds a missing test to `ArticleContentFetcherTest` that verifies `<article>` wins over `[role=main]` when both elements are present on the same page
- The HTML places `<div role="main">` before `<article>` in the DOM to test the adversarial ordering

## Test plan

- [x] New test `article element takes priority over role=main` passes (GREEN — impl was already correct, just untested)
- [x] Full `ArticleContentFetcherTest` class passes (all 7 tests)

Closes #89