### PR TITLE
[#91] fix: show Toast when no browser app is installed

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreen.kt
@@ -3,6 +3,7 @@ package com.hopescrolling.ui.screens
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -88,7 +89,9 @@ fun ArticleReaderScreen(viewModel: ArticleReaderViewModel) {
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                         try {
                             context.startActivity(intent)
-                        } catch (_: ActivityNotFoundException) {}
+                        } catch (_: ActivityNotFoundException) {
+                            Toast.makeText(context, "No browser app found", Toast.LENGTH_SHORT).show()
+                        }
                     },
                     modifier = Modifier.testTag("reader_open_in_browser"),
                 ) {

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
 import com.hopescrolling.data.article.ArticleContent
 import com.hopescrolling.util.FakeArticleContentFetcher
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +20,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowToast
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -43,6 +47,22 @@ class ArticleReaderScreenTest {
         composeTestRule.onNodeWithTag("reader_error").assertIsDisplayed()
         composeTestRule.onNodeWithTag("reader_open_in_browser").assertIsDisplayed()
         composeTestRule.onNodeWithTag("reader_open_in_browser").assertHasClickAction()
+    }
+
+    @Test
+    fun readerScreen_showsToastWhenNoBrowserAppFound() {
+        val app = ApplicationProvider.getApplicationContext<android.app.Application>()
+        Shadows.shadowOf(app).checkActivities(true)
+
+        val viewModel = ArticleReaderViewModel(
+            FakeArticleContentFetcher(Result.failure(RuntimeException("connection refused"))),
+            "https://example.com/article",
+        )
+        composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("reader_open_in_browser").performClick()
+
+        assert(ShadowToast.getTextOfLatestToast() == "No browser app found")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `Toast.makeText(context, "No browser app found", Toast.LENGTH_SHORT).show()` to the `ActivityNotFoundException` catch block in `ArticleReaderScreen`'s "Open in browser" button, replacing the previous silent no-op
- Adds a Robolectric unit test `readerScreen_showsToastWhenNoBrowserAppFound` that uses `Shadows.shadowOf(app).checkActivities(true)` to trigger the exception path and asserts the toast message via `ShadowToast`

## Test plan

- [x] New test `readerScreen_showsToastWhenNoBrowserAppFound` confirms RED before fix, GREEN after
- [x] Full unit test suite passes: `./gradlew :app:testDebugUnitTest`

Closes #91