### PR TITLE
docs: clarify git workflow rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Never `git push` unless explicitly told to.
 
-Each PR must have exactly one commit. All fixes and follow-ups go into the same commit via `git commit --amend`, not as new commits. If the branch contains multiple unrelated commits, first fetch and check whether any earlier PRs have already merged into `main` (`git fetch origin && git log origin/main..HEAD`) — the branch may look clean once main is up to date. Only if genuinely unrelated commits remain should you create a separate PR for each by cherry-picking onto a fresh branch from `main`.
+Before starting any work, run `git fetch origin && git rebase origin/main` to ensure the branch is up to date.
+
+Each PR must have exactly one commit and must target `main`. All fixes and follow-ups go into the same commit via `git commit --amend`, not as new commits. If the branch contains multiple unrelated commits, first fetch and check whether any earlier PRs have already merged into `main` (`git fetch origin && git log origin/main..HEAD`) — the branch may look clean once main is up to date. Only if genuinely unrelated commits remain should you create a separate PR for each by cherry-picking onto a fresh branch from `main`.
 
 When asked to "automerge": fetch origin, check `git log origin/main..HEAD` and open PRs (`gh pr list`) to understand the current state, then create a PR for the latest commit and enable automerge (`gh pr merge --auto --rebase`).
 
 After every commit, launch a subagent to review it (`git show HEAD`) and report findings before proceeding. If the commit touches any amended files, re-run the review on the amended commit before considering the work done.
 
-Every finding raised by the reviewer must be either fixed (in the current commit via amend) or tracked as a GitHub issue. Do not silently ignore reviewer findings. If a finding is out of scope for the current PR, file an issue for it before moving on.
+Every finding raised by the reviewer must be either fixed (in the current commit via amend) or tracked as a GitHub issue. Do not silently ignore reviewer findings. If the finding was introduced by this commit, fix it directly via amend. If it is pre-existing, fix it now only if the change is small and safe — otherwise file an issue for later.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Require `git fetch origin && git rebase origin/main` before starting any work
- Specify that PRs must target `main`
- Refine reviewer finding policy: fix inline if introduced by this commit; file an issue if pre-existing and non-trivial

🤖 Generated with [Claude Code](https://claude.com/claude-code)