### PR TITLE
test: fix UncaughtExceptionsBeforeTest in loading indicator test

### DIFF
--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
@@ -10,7 +10,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.hopescrolling.data.article.ArticleContent
 import com.hopescrolling.util.FakeArticleContentFetcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -111,9 +110,7 @@ class ArticleReaderScreenTest {
 
     @Test
     fun readerScreen_showsLoadingIndicatorWhileLoading() {
-        val dispatcher = StandardTestDispatcher()
-        Dispatchers.setMain(dispatcher)
-        val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(), "https://example.com")
+        val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(result = null), "https://example.com")
         composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("reader_loading").assertIsDisplayed()

--- a/app/src/test/kotlin/com/hopescrolling/util/FakeArticleContentFetcher.kt
+++ b/app/src/test/kotlin/com/hopescrolling/util/FakeArticleContentFetcher.kt
@@ -2,11 +2,13 @@ package com.hopescrolling.util
 
 import com.hopescrolling.data.article.ArticleContent
 import com.hopescrolling.data.article.ArticleContentFetcher
+import kotlinx.coroutines.awaitCancellation
 
 class FakeArticleContentFetcher(
-    private val result: Result<ArticleContent> = Result.success(
+    private val result: Result<ArticleContent>? = Result.success(
         ArticleContent(title = "Test Title", paragraphs = listOf("Test paragraph")),
     ),
 ) : ArticleContentFetcher {
-    override suspend fun fetch(url: String): Result<ArticleContent> = result
+    override suspend fun fetch(url: String): Result<ArticleContent> =
+        result ?: awaitCancellation()
 }


### PR DESCRIPTION
## Summary

- `readerScreen_showsLoadingIndicatorWhileLoading` was calling `Dispatchers.setMain(StandardTestDispatcher())` inside the test body, leaving a pending coroutine after `resetMain()`, which surfaced as `UncaughtExceptionsBeforeTest` in the next test alphabetically (`readerScreen_showsToastWhenNoBrowserAppFound`)
- Fix: `FakeArticleContentFetcher` now accepts `result: Result<ArticleContent>?`; passing `null` suspends via `awaitCancellation()` instead of manipulating `Dispatchers.Main`

## Test plan

- [ ] `ArticleReaderScreenTest` passes locally (all 6 tests green)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)