### PR TITLE
test: prevent Coil network requests in ArticleReaderScreenTest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     testImplementation(libs.mockwebserver)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.coil.test)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
@@ -7,6 +7,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import coil.Coil
+import coil.ImageLoader
+import coil.test.FakeImageLoaderEngine
 import com.hopescrolling.data.article.ArticleContent
 import com.hopescrolling.util.FakeArticleContentFetcher
 import kotlinx.coroutines.Dispatchers
@@ -22,7 +27,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
 import org.robolectric.shadows.ShadowToast
 
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, coil.annotation.ExperimentalCoilApi::class)
 @RunWith(RobolectricTestRunner::class)
 class ArticleReaderScreenTest {
 
@@ -30,10 +35,20 @@ class ArticleReaderScreenTest {
     val composeTestRule = createComposeRule()
 
     @Before
-    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val engine = FakeImageLoaderEngine.Builder()
+            .default(ColorDrawable(Color.TRANSPARENT))
+            .build()
+        Coil.setImageLoader(ImageLoader.Builder(context).components { add(engine) }.build())
+    }
 
     @After
-    fun tearDown() = Dispatchers.resetMain()
+    fun tearDown() {
+        Dispatchers.resetMain()
+        Coil.reset()
+    }
 
     @Test
     fun readerScreen_showsErrorMessage() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+coil-test = { group = "io.coil-kt", name = "coil-test", version.ref = "coil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

- `AsyncImage` (Coil) was making real HTTP requests on CI (Linux); the background thread failure landed in the next test's coroutine exception captor, causing `UncaughtExceptionsBeforeTest` in `readerScreen_showsToastWhenNoBrowserAppFound`
- Added `coil-test` dependency and installed `FakeImageLoaderEngine` in `@Before` to intercept all image requests and return a transparent drawable — no network calls
- `Coil.reset()` in `@After` cleans up the global loader between tests

## Test plan

- [ ] All `ArticleReaderScreenTest` tests pass locally (debug + release)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)