### PR TITLE
[#109] ci: embed monotonic version code from GITHUB_RUN_NUMBER in BuildConfig

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,15 +25,11 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
-      - name: Compute short SHA
-        id: sha
-        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Publish versioned release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: release-${{ steps.sha.outputs.short }}
-          name: release-${{ steps.sha.outputs.short }}
+          tag_name: build-${{ github.run_number }}
+          name: build-${{ github.run_number }}
           make_latest: true
           files: app/build/outputs/apk/debug/app-debug.apk
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.hopescrolling"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull() ?: 1
+        versionName = System.getenv("GITHUB_RUN_NUMBER")?.let { "build-$it" } ?: "local"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -53,6 +53,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     testOptions {


### PR DESCRIPTION
Closes #109

## Summary
- `versionCode` reads `GITHUB_RUN_NUMBER` from the environment (fallback: `1` for local builds)
- `versionName` is set to `"build-<run>"` (fallback: `"local"`)
- `buildConfig = true` enabled so `BuildConfig.VERSION_CODE`/`VERSION_NAME` are accessible at runtime
- GitHub release tag and name updated to `build-<run>` for consistency

## Test plan
- [ ] Local build succeeds with fallback values (`versionCode = 1`, `versionName = "local"`)
- [ ] CI build sets `versionCode = GITHUB_RUN_NUMBER` and tags the release `build-<N>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)