### PR TITLE
fix: follow HTTP→HTTPS redirects and normalize schemeless feed URLs

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
@@ -12,17 +12,28 @@ fun interface RssFeedFetcher {
 
 fun httpRssFeedFetcher(): RssFeedFetcher = RssFeedFetcher { url ->
     withContext(Dispatchers.IO) {
-        val connection = URL(url).openConnection() as HttpURLConnection
-        try {
-            connection.connectTimeout = 10_000
-            connection.readTimeout = 30_000
-            val responseCode = connection.responseCode
-            if (responseCode !in 200..299) {
-                throw IOException("HTTP $responseCode for $url")
+        fetchFollowingRedirects(url, remainingRedirects = 5)
+    }
+}
+
+private fun fetchFollowingRedirects(url: String, remainingRedirects: Int): String {
+    if (remainingRedirects <= 0) throw IOException("Too many redirects for $url")
+    val connection = URL(url).openConnection() as HttpURLConnection
+    connection.instanceFollowRedirects = false
+    connection.connectTimeout = 10_000
+    connection.readTimeout = 30_000
+    return try {
+        val responseCode = connection.responseCode
+        when {
+            responseCode in 300..399 -> {
+                val location = connection.getHeaderField("Location")
+                    ?: throw IOException("Redirect with no Location header for $url")
+                fetchFollowingRedirects(URL(URL(url), location).toString(), remainingRedirects - 1)
             }
-            connection.inputStream.bufferedReader().readText()
-        } finally {
-            connection.disconnect()
+            responseCode !in 200..299 -> throw IOException("HTTP $responseCode for $url")
+            else -> connection.inputStream.bufferedReader().readText()
         }
+    } finally {
+        connection.disconnect()
     }
 }

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/SettingsViewModel.kt
@@ -18,7 +18,8 @@ class SettingsViewModel(
 
     fun addFeed(url: String) {
         viewModelScope.launch {
-            repository.add(FeedSource(id = UUID.randomUUID().toString(), name = url, url = url))
+            val normalizedUrl = if (url.startsWith("http://") || url.startsWith("https://")) url else "https://$url"
+            repository.add(FeedSource(id = UUID.randomUUID().toString(), name = normalizedUrl, url = normalizedUrl))
         }
     }
 

--- a/app/src/test/kotlin/com/hopescrolling/data/article/RssFeedFetcherTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/article/RssFeedFetcherTest.kt
@@ -50,9 +50,47 @@ class RssFeedFetcherTest {
     }
 
     @Test
-    fun `malformed URL throws before making network call`() {
+    fun `malformed url throws IOException`() {
         val fetcher = httpRssFeedFetcher()
-        assertThrows(Exception::class.java) { runBlocking { fetcher.fetch("not-a-url") } }
+        assertThrows(IOException::class.java) { runBlocking { fetcher.fetch("not-a-url") } }
+    }
+
+    @Test
+    fun `301 redirect is followed to new url`() = runTest {
+        val finalUrl = server.url("/final").toString()
+        server.enqueue(MockResponse().setResponseCode(301).addHeader("Location", finalUrl))
+        server.enqueue(MockResponse().setBody("<rss/>").setResponseCode(200))
+        val fetcher = httpRssFeedFetcher()
+        val result = fetcher.fetch(server.url("/original").toString())
+        assertEquals("<rss/>", result)
+    }
+
+    @Test
+    fun `302 redirect is followed to new url`() = runTest {
+        val finalUrl = server.url("/final").toString()
+        server.enqueue(MockResponse().setResponseCode(302).addHeader("Location", finalUrl))
+        server.enqueue(MockResponse().setBody("<rss/>").setResponseCode(200))
+        val fetcher = httpRssFeedFetcher()
+        val result = fetcher.fetch(server.url("/original").toString())
+        assertEquals("<rss/>", result)
+    }
+
+    @Test
+    fun `too many redirects throws IOException`() {
+        val url = server.url("/feed").toString()
+        repeat(5) { server.enqueue(MockResponse().setResponseCode(301).addHeader("Location", url)) }
+        val fetcher = httpRssFeedFetcher()
+        val ex = assertThrows(IOException::class.java) { runBlocking { fetcher.fetch(url) } }
+        assert(ex.message!!.contains("Too many redirects")) { "Expected 'Too many redirects' in: ${ex.message}" }
+    }
+
+    @Test
+    fun `relative Location header is resolved against base url`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(301).addHeader("Location", "/final"))
+        server.enqueue(MockResponse().setBody("<rss/>").setResponseCode(200))
+        val fetcher = httpRssFeedFetcher()
+        val result = fetcher.fetch(server.url("/original").toString())
+        assertEquals("<rss/>", result)
     }
 
     @Test

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/SettingsViewModelTest.kt
@@ -57,6 +57,19 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `addFeed prepends https when url has no scheme`() = runTest {
+        val repo = FakeFeedSourceRepository()
+        val viewModel = SettingsViewModel(repo)
+
+        viewModel.addFeed("example.com/feed")
+
+        val sources = viewModel.feedSources.first()
+        assertEquals(1, sources.size)
+        assertEquals("https://example.com/feed", sources[0].url)
+        assertEquals("https://example.com/feed", sources[0].name)
+    }
+
+    @Test
     fun `renameFeed updates the name of the source with the given id`() = runTest {
         val repo = FakeFeedSourceRepository()
         val source = FeedSource(id = "1", name = "Old Name", url = "https://example.com/feed")


### PR DESCRIPTION
Two bugs caused any newly added feed to silently return no articles:

1. RssFeedFetcher used HttpURLConnection's default follow-redirects, which
   does not cross protocol boundaries. A feed on http:// that redirects to
   https:// got an HTTP 301 response, which was treated as an error and
   swallowed as an empty list. Fixed by setting instanceFollowRedirects=false
   and manually following Location headers up to 5 hops.

2. SettingsViewModel.addFeed stored the URL exactly as typed. Entering a URL
   without a scheme (e.g. "sloanreview.mit.edu/feed") caused
   MalformedURLException in the fetcher, also silently swallowed. Fixed by
   prepending "https://" when no "://" is present in the input.

https://claude.ai/code/session_01S76DdSe9A5wXWuTFVEw3cc