### PR TITLE
[#113] feat: show update badge dot on Timeline settings icon

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/AppContainer.kt
+++ b/app/src/main/kotlin/com/hopescrolling/AppContainer.kt
@@ -16,6 +16,13 @@ import com.hopescrolling.data.readstate.ReadStateRepository
 import com.hopescrolling.data.readstate.RoomReadStateRepository
 import com.hopescrolling.data.update.AppUpdateRepository
 import com.hopescrolling.data.update.HttpAppUpdateRepository
+import com.hopescrolling.data.update.UpdateState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 class AppContainer(context: Context) {
     val feedSourceRepository: FeedSourceRepository by lazy {
@@ -49,6 +56,15 @@ class AppContainer(context: Context) {
             apiUrl = GITHUB_RELEASES_API_URL,
             currentVersionCode = BuildConfig.VERSION_CODE,
         )
+    }
+
+    private val _updateAvailable = MutableStateFlow(false)
+    val updateAvailable: StateFlow<Boolean> = _updateAvailable
+
+    init {
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            _updateAvailable.value = appUpdateRepository.getUpdateState() is UpdateState.UpdateAvailable
+        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.foundation.layout.padding
@@ -18,8 +19,15 @@ import androidx.compose.ui.Modifier
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.StateFlow
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -38,7 +46,7 @@ private const val ROUTE_READER = "reader/{encodedUrl}"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppNavigation() {
+fun AppNavigation(updateAvailable: StateFlow<Boolean>? = null) {
     val context = LocalContext.current
     val container = remember { AppContainer(context) }
     val navController = rememberNavController()
@@ -47,6 +55,7 @@ fun AppNavigation() {
     val readerUrl = if (currentRoute?.startsWith("reader/") == true) {
         backStackEntry?.arguments?.getString("encodedUrl")?.let { Uri.decode(it) }
     } else null
+    val badgeVisible by (updateAvailable ?: container.updateAvailable).collectAsState()
 
     Scaffold(
         topBar = {
@@ -78,11 +87,25 @@ fun AppNavigation() {
                         }
                     }
                     if (currentRoute == ROUTE_TIMELINE) {
-                        IconButton(
-                            onClick = { navController.navigate(ROUTE_SETTINGS) },
-                            modifier = Modifier.testTag("manage_feeds_button"),
-                        ) {
-                            Icon(Icons.Default.Settings, contentDescription = "Manage feeds")
+                        Box {
+                            IconButton(
+                                onClick = { navController.navigate(ROUTE_SETTINGS) },
+                                modifier = Modifier.testTag("manage_feeds_button"),
+                            ) {
+                                Icon(Icons.Default.Settings, contentDescription = "Manage feeds")
+                            }
+                            if (badgeVisible) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(8.dp)
+                                        .background(
+                                            color = MaterialTheme.colorScheme.error,
+                                            shape = CircleShape,
+                                        )
+                                        .align(androidx.compose.ui.Alignment.TopEnd)
+                                        .testTag("update_badge_dot"),
+                                )
+                            }
                         }
                     }
                 },

--- a/app/src/test/kotlin/com/hopescrolling/NavigationTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/NavigationTest.kt
@@ -23,6 +23,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.hopescrolling.ui.navigation.AppNavigation
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -159,5 +161,19 @@ class NavigationTest {
         composeTestRule.onNodeWithTag("settings_screen").assertIsDisplayed()
         composeTestRule.onNodeWithTag("back_button").performClick()
         composeTestRule.onNodeWithTag("timeline_screen").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsBadgeDotWhenUpdateAvailable() {
+        composeTestRule.setContent { AppNavigation(updateAvailable = MutableStateFlow(true)) }
+
+        composeTestRule.onNodeWithTag("update_badge_dot").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_hidesBadgeDotWhenNoUpdateAvailable() {
+        composeTestRule.setContent { AppNavigation(updateAvailable = MutableStateFlow(false)) }
+
+        composeTestRule.onNodeWithTag("update_badge_dot").assertDoesNotExist()
     }
 }


### PR DESCRIPTION
## Summary

- `AppContainer` runs a one-shot background coroutine on init that calls `AppUpdateRepository` and exposes the result as `StateFlow<Boolean>` (`updateAvailable`)
- `AppNavigation` accepts an optional `updateAvailable: StateFlow<Boolean>?` (uses `container.updateAvailable` when null) and overlays a red badge dot on the settings gear icon when an update is available
- Badge state is set once at launch and unchanged during the session

## Test plan

- [ ] `NavigationTest`: badge dot tag is present when `updateAvailable = true`, absent when `false`

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)