### PR TITLE
[#114] feat: wire Download Update button via DownloadManager

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/kotlin/com/hopescrolling/AppContainer.kt
+++ b/app/src/main/kotlin/com/hopescrolling/AppContainer.kt
@@ -16,6 +16,13 @@ import com.hopescrolling.data.readstate.ReadStateRepository
 import com.hopescrolling.data.readstate.RoomReadStateRepository
 import com.hopescrolling.data.update.AppUpdateRepository
 import com.hopescrolling.data.update.HttpAppUpdateRepository
+import com.hopescrolling.data.update.UpdateState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 class AppContainer(context: Context) {
     val feedSourceRepository: FeedSourceRepository by lazy {
@@ -49,6 +56,15 @@ class AppContainer(context: Context) {
             apiUrl = GITHUB_RELEASES_API_URL,
             currentVersionCode = BuildConfig.VERSION_CODE,
         )
+    }
+
+    private val _updateAvailable = MutableStateFlow(false)
+    val updateAvailable: StateFlow<Boolean> = _updateAvailable
+
+    init {
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            _updateAvailable.value = appUpdateRepository.getUpdateState() is UpdateState.UpdateAvailable
+        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.foundation.layout.padding
@@ -18,8 +19,15 @@ import androidx.compose.ui.Modifier
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.StateFlow
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -38,7 +46,7 @@ private const val ROUTE_READER = "reader/{encodedUrl}"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppNavigation() {
+fun AppNavigation(updateAvailable: StateFlow<Boolean>? = null) {
     val context = LocalContext.current
     val container = remember { AppContainer(context) }
     val navController = rememberNavController()
@@ -47,6 +55,7 @@ fun AppNavigation() {
     val readerUrl = if (currentRoute?.startsWith("reader/") == true) {
         backStackEntry?.arguments?.getString("encodedUrl")?.let { Uri.decode(it) }
     } else null
+    val badgeVisible by (updateAvailable ?: container.updateAvailable).collectAsState()
 
     Scaffold(
         topBar = {
@@ -78,11 +87,25 @@ fun AppNavigation() {
                         }
                     }
                     if (currentRoute == ROUTE_TIMELINE) {
-                        IconButton(
-                            onClick = { navController.navigate(ROUTE_SETTINGS) },
-                            modifier = Modifier.testTag("manage_feeds_button"),
-                        ) {
-                            Icon(Icons.Default.Settings, contentDescription = "Manage feeds")
+                        Box {
+                            IconButton(
+                                onClick = { navController.navigate(ROUTE_SETTINGS) },
+                                modifier = Modifier.testTag("manage_feeds_button"),
+                            ) {
+                                Icon(Icons.Default.Settings, contentDescription = "Manage feeds")
+                            }
+                            if (badgeVisible) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(8.dp)
+                                        .background(
+                                            color = MaterialTheme.colorScheme.error,
+                                            shape = CircleShape,
+                                        )
+                                        .align(androidx.compose.ui.Alignment.TopEnd)
+                                        .testTag("update_badge_dot"),
+                                )
+                            }
                         }
                     }
                 },

--- a/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/navigation/AppNavigation.kt
@@ -125,7 +125,16 @@ fun AppNavigation(updateAvailable: StateFlow<Boolean>? = null) {
             }
             composable(ROUTE_SETTINGS) {
                 val viewModel = viewModel { SettingsViewModel(container.feedSourceRepository, container.appUpdateRepository) }
-                SettingsScreen(viewModel)
+                SettingsScreen(viewModel, onDownloadUpdate = { apkUrl ->
+                    val dm = context.getSystemService(android.app.DownloadManager::class.java)
+                    val request = android.app.DownloadManager.Request(Uri.parse(apkUrl))
+                        .setDestinationInExternalPublicDir(
+                            android.os.Environment.DIRECTORY_DOWNLOADS,
+                            "hopescrolling-update.apk",
+                        )
+                        .setNotificationVisibility(android.app.DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                    dm?.enqueue(request)
+                })
             }
             composable(ROUTE_READER) { backStackEntry ->
                 val encodedUrl = backStackEntry.arguments?.getString("encodedUrl") ?: return@composable

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/SettingsScreen.kt
@@ -29,9 +29,13 @@ import com.hopescrolling.data.feed.FeedSource
 import com.hopescrolling.data.update.UpdateState
 
 @Composable
-fun SettingsScreen(viewModel: SettingsViewModel) {
+fun SettingsScreen(
+    viewModel: SettingsViewModel,
+    onDownloadUpdate: (String) -> Unit = {},
+) {
     val feedSources by viewModel.feedSources.collectAsState()
     val updateState by viewModel.updateState.collectAsState()
+    val isDownloading by viewModel.isDownloading.collectAsState()
     var addUrl by remember { mutableStateOf("") }
     var renameState by remember { mutableStateOf<Pair<FeedSource, String>?>(null) }
 
@@ -41,7 +45,14 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
             .testTag("settings_screen")
             .padding(16.dp),
     ) {
-        AppUpdateSection(updateState)
+        AppUpdateSection(
+            state = updateState,
+            isDownloading = isDownloading,
+            onDownload = { apkUrl ->
+                viewModel.startDownload()
+                onDownloadUpdate(apkUrl)
+            },
+        )
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -132,7 +143,11 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
 }
 
 @Composable
-private fun AppUpdateSection(state: UpdateState) {
+private fun AppUpdateSection(
+    state: UpdateState,
+    isDownloading: Boolean = false,
+    onDownload: (String) -> Unit = {},
+) {
     when (state) {
         UpdateState.Loading -> CircularProgressIndicator(modifier = Modifier.testTag("update_loading"))
         UpdateState.UpToDate -> Text(
@@ -148,6 +163,13 @@ private fun AppUpdateSection(state: UpdateState) {
                 text = "Latest: ${state.latestLabel}",
                 modifier = Modifier.testTag("update_latest_version"),
             )
+            Button(
+                onClick = { onDownload(state.apkUrl) },
+                enabled = !isDownloading,
+                modifier = Modifier.testTag("update_download_button"),
+            ) {
+                Text(if (isDownloading) "Downloading..." else "Download Update")
+            }
         }
         UpdateState.Error -> Text(
             text = "Could not check for updates",

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/SettingsViewModel.kt
@@ -24,10 +24,17 @@ class SettingsViewModel(
     private val _updateState = MutableStateFlow<UpdateState>(UpdateState.Loading)
     val updateState: StateFlow<UpdateState> = _updateState.asStateFlow()
 
+    private val _isDownloading = MutableStateFlow(false)
+    val isDownloading: StateFlow<Boolean> = _isDownloading.asStateFlow()
+
     init {
         viewModelScope.launch {
             _updateState.value = appUpdateRepository.getUpdateState()
         }
+    }
+
+    fun startDownload() {
+        _isDownloading.value = true
     }
 
     fun addFeed(url: String) {

--- a/app/src/test/kotlin/com/hopescrolling/NavigationTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/NavigationTest.kt
@@ -23,6 +23,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.hopescrolling.ui.navigation.AppNavigation
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -159,5 +161,19 @@ class NavigationTest {
         composeTestRule.onNodeWithTag("settings_screen").assertIsDisplayed()
         composeTestRule.onNodeWithTag("back_button").performClick()
         composeTestRule.onNodeWithTag("timeline_screen").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_showsBadgeDotWhenUpdateAvailable() {
+        composeTestRule.setContent { AppNavigation(updateAvailable = MutableStateFlow(true)) }
+
+        composeTestRule.onNodeWithTag("update_badge_dot").assertIsDisplayed()
+    }
+
+    @Test
+    fun timelineScreen_hidesBadgeDotWhenNoUpdateAvailable() {
+        composeTestRule.setContent { AppNavigation(updateAvailable = MutableStateFlow(false)) }
+
+        composeTestRule.onNodeWithTag("update_badge_dot").assertDoesNotExist()
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/SettingsScreenTest.kt
@@ -142,4 +142,24 @@ class SettingsScreenTest {
 
         composeTestRule.onNodeWithTag("update_error").assertIsDisplayed()
     }
+
+    @Test
+    fun settingsScreen_showsDownloadButtonWhenUpdateAvailable() {
+        val state = UpdateState.UpdateAvailable(latestLabel = "Build 42", apkUrl = "https://example.com/app.apk")
+        val viewModel = SettingsViewModel(FakeFeedSourceRepository(), FakeAppUpdateRepository(state))
+        composeTestRule.setContent { SettingsScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("update_download_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun settingsScreen_downloadButtonDisabledAfterClick() {
+        val state = UpdateState.UpdateAvailable(latestLabel = "Build 42", apkUrl = "https://example.com/app.apk")
+        val viewModel = SettingsViewModel(FakeFeedSourceRepository(), FakeAppUpdateRepository(state))
+        composeTestRule.setContent { SettingsScreen(viewModel = viewModel, onDownloadUpdate = {}) }
+
+        composeTestRule.onNodeWithTag("update_download_button").performClick()
+
+        composeTestRule.onNodeWithText("Downloading...").assertIsDisplayed()
+    }
 }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/SettingsViewModelTest.kt
@@ -122,4 +122,20 @@ class SettingsViewModelTest {
 
         assertEquals(UpdateState.Error, state)
     }
+
+    @Test
+    fun `isDownloading is false initially`() = runTest {
+        val viewModel = SettingsViewModel(FakeFeedSourceRepository(), FakeAppUpdateRepository())
+
+        assertEquals(false, viewModel.isDownloading.value)
+    }
+
+    @Test
+    fun `startDownload sets isDownloading to true`() = runTest {
+        val viewModel = SettingsViewModel(FakeFeedSourceRepository(), FakeAppUpdateRepository())
+
+        viewModel.startDownload()
+
+        assertEquals(true, viewModel.isDownloading.value)
+    }
 }


### PR DESCRIPTION
## Summary

- `SettingsViewModel` exposes `isDownloading: StateFlow<Boolean>` and `startDownload()` — calling `startDownload()` disables the button to prevent duplicate enqueues
- `SettingsScreen` shows a "Download Update" button in the `UpdateAvailable` state; tapping it calls `startDownload()` then the `onDownloadUpdate` callback
- `AppNavigation` wires `onDownloadUpdate` to enqueue the APK via `DownloadManager` with `VISIBILITY_VISIBLE_NOTIFY_COMPLETED` (Android handles the install prompt on completion)
- `REQUEST_INSTALL_PACKAGES` added to `AndroidManifest.xml`

## Test plan

- [ ] `SettingsViewModelTest`: `isDownloading` starts `false`, becomes `true` after `startDownload()`
- [ ] `SettingsScreenTest`: download button shown in `UpdateAvailable` state; button shows "Downloading..." and is disabled after click

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)