### PR TITLE
[#85] test: fix misleading formatPubDate_epoch_returnsNull test body

### DIFF
--- a/app/src/test/kotlin/com/hopescrolling/data/article/PubDateFormatterTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/article/PubDateFormatterTest.kt
@@ -48,7 +48,7 @@ class PubDateFormatterTest {
 
     @Test
     fun formatPubDate_epoch_returnsNull() {
-        // Epoch signals a parse failure — should return null
-        assertNull(formatPubDate("garbage", now))
+        // A date string that parses to Instant.EPOCH triggers the sentinel check → null
+        assertNull(formatPubDate("Thu, 01 Jan 1970 00:00:00 GMT", now))
     }
 }


### PR DESCRIPTION
Replace the `"garbage"` string with an actual epoch date string (`"Thu, 01 Jan 1970 00:00:00 GMT"`) so the test exercises the `Instant.EPOCH` sentinel check in `formatPubDate` rather than duplicating the unparseable-input path already covered by `formatPubDate_unparseable_returnsNull`.

Closes #85