### PR TITLE
[#120] refactor: inject CoroutineDispatcher into HttpAppUpdateRepository, RssFeedFetcher, ArticleContentFetcher

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContentFetcher.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContentFetcher.kt
@@ -1,5 +1,6 @@
 package com.hopescrolling.data.article
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jsoup.Jsoup
@@ -13,10 +14,13 @@ interface ArticleContentFetcher {
     suspend fun fetch(url: String): Result<ArticleContent>
 }
 
-fun jsoupArticleContentFetcher(): ArticleContentFetcher = JsoupArticleContentFetcher()
+fun jsoupArticleContentFetcher(dispatcher: CoroutineDispatcher = Dispatchers.IO): ArticleContentFetcher =
+    JsoupArticleContentFetcher(dispatcher)
 
-private class JsoupArticleContentFetcher : ArticleContentFetcher {
-    override suspend fun fetch(url: String): Result<ArticleContent> = withContext(Dispatchers.IO) {
+private class JsoupArticleContentFetcher(
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ArticleContentFetcher {
+    override suspend fun fetch(url: String): Result<ArticleContent> = withContext(dispatcher) {
         runCatching {
             val html = fetchHtml(url)
             parseContent(html, url)

--- a/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/RssFeedFetcher.kt
@@ -1,5 +1,6 @@
 package com.hopescrolling.data.article
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -10,8 +11,8 @@ fun interface RssFeedFetcher {
     suspend fun fetch(url: String): String
 }
 
-fun httpRssFeedFetcher(): RssFeedFetcher = RssFeedFetcher { url ->
-    withContext(Dispatchers.IO) {
+fun httpRssFeedFetcher(dispatcher: CoroutineDispatcher = Dispatchers.IO): RssFeedFetcher = RssFeedFetcher { url ->
+    withContext(dispatcher) {
         fetchFollowingRedirects(url, remainingRedirects = 5)
     }
 }

--- a/app/src/main/kotlin/com/hopescrolling/data/update/HttpAppUpdateRepository.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/update/HttpAppUpdateRepository.kt
@@ -1,5 +1,6 @@
 package com.hopescrolling.data.update
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -9,9 +10,10 @@ import java.net.URL
 class HttpAppUpdateRepository(
     private val apiUrl: String,
     private val currentVersionCode: Int,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AppUpdateRepository {
 
-    override suspend fun getUpdateState(): UpdateState = withContext(Dispatchers.IO) {
+    override suspend fun getUpdateState(): UpdateState = withContext(dispatcher) {
         try {
             val json = fetch(apiUrl)
             val releases = JSONArray(json)

--- a/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
@@ -1,5 +1,6 @@
 package com.hopescrolling.data.article
 
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -9,6 +10,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ArticleContentFetcherTest {
     private lateinit var server: MockWebServer
 
@@ -21,6 +23,13 @@ class ArticleContentFetcherTest {
     @After
     fun tearDown() {
         server.shutdown()
+    }
+
+    @Test
+    fun `accepts injected dispatcher`() = runTest {
+        server.enqueue(MockResponse().setBody("<html><body><article><p>Hello</p></article></body></html>").setResponseCode(200))
+        val result = jsoupArticleContentFetcher(UnconfinedTestDispatcher(testScheduler)).fetch(server.url("/").toString())
+        assertTrue(result.isSuccess)
     }
 
     @Test

--- a/app/src/test/kotlin/com/hopescrolling/data/article/RssFeedFetcherTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/article/RssFeedFetcherTest.kt
@@ -1,6 +1,7 @@
 package com.hopescrolling.data.article
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -10,6 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.IOException
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class RssFeedFetcherTest {
     private lateinit var server: MockWebServer
 
@@ -22,6 +24,13 @@ class RssFeedFetcherTest {
     @After
     fun tearDown() {
         server.shutdown()
+    }
+
+    @Test
+    fun `accepts injected dispatcher`() = runTest {
+        server.enqueue(MockResponse().setBody("<rss/>").setResponseCode(200))
+        val fetcher = httpRssFeedFetcher(UnconfinedTestDispatcher(testScheduler))
+        assertEquals("<rss/>", fetcher.fetch(server.url("/feed").toString()))
     }
 
     @Test

--- a/app/src/test/kotlin/com/hopescrolling/data/update/AppUpdateRepositoryTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/update/AppUpdateRepositoryTest.kt
@@ -1,5 +1,7 @@
 package com.hopescrolling.data.update
 
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -8,6 +10,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class AppUpdateRepositoryTest {
     private lateinit var server: MockWebServer
 
@@ -22,14 +25,16 @@ class AppUpdateRepositoryTest {
         server.shutdown()
     }
 
+    private fun TestScope.repo(currentVersionCode: Int) = HttpAppUpdateRepository(
+        apiUrl = server.url("/releases").toString(),
+        currentVersionCode = currentVersionCode,
+        dispatcher = UnconfinedTestDispatcher(testScheduler),
+    )
+
     @Test
     fun `returns Error on non-2xx response`() = runTest {
         server.enqueue(MockResponse().setResponseCode(500))
-        val repo = HttpAppUpdateRepository(
-            apiUrl = server.url("/releases").toString(),
-            currentVersionCode = 1,
-        )
-        assertEquals(UpdateState.Error, repo.getUpdateState())
+        assertEquals(UpdateState.Error, repo(1).getUpdateState())
     }
 
     @Test
@@ -39,11 +44,7 @@ class AppUpdateRepositoryTest {
                 """[{"tag_name":"build-1","name":"build-1","assets":[{"name":"app-debug.apk","browser_download_url":"https://example.com/app.apk"}]}]"""
             )
         )
-        val repo = HttpAppUpdateRepository(
-            apiUrl = server.url("/releases").toString(),
-            currentVersionCode = 5,
-        )
-        assertEquals(UpdateState.UpToDate, repo.getUpdateState())
+        assertEquals(UpdateState.UpToDate, repo(5).getUpdateState())
     }
 
     @Test
@@ -53,13 +54,9 @@ class AppUpdateRepositoryTest {
                 """[{"tag_name":"build-5","name":"build-5","assets":[{"name":"app-debug.apk","browser_download_url":"https://example.com/app.apk"}]}]"""
             )
         )
-        val repo = HttpAppUpdateRepository(
-            apiUrl = server.url("/releases").toString(),
-            currentVersionCode = 1,
-        )
         assertEquals(
             UpdateState.UpdateAvailable("build-5", "https://example.com/app.apk"),
-            repo.getUpdateState(),
+            repo(1).getUpdateState(),
         )
     }
 
@@ -70,21 +67,13 @@ class AppUpdateRepositoryTest {
                 """[{"tag_name":"build-5","name":"build-5","assets":[]}]"""
             )
         )
-        val repo = HttpAppUpdateRepository(
-            apiUrl = server.url("/releases").toString(),
-            currentVersionCode = 1,
-        )
-        assertEquals(UpdateState.UpToDate, repo.getUpdateState())
+        assertEquals(UpdateState.UpToDate, repo(1).getUpdateState())
     }
 
     @Test
     fun `returns UpToDate when releases array is empty`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
-        val repo = HttpAppUpdateRepository(
-            apiUrl = server.url("/releases").toString(),
-            currentVersionCode = 1,
-        )
-        assertEquals(UpdateState.UpToDate, repo.getUpdateState())
+        assertEquals(UpdateState.UpToDate, repo(1).getUpdateState())
     }
 
     @Test
@@ -94,10 +83,6 @@ class AppUpdateRepositoryTest {
                 """[{"tag_name":"v1.0.0","name":"v1.0.0","assets":[{"name":"app-debug.apk","browser_download_url":"https://example.com/app.apk"}]}]"""
             )
         )
-        val repo = HttpAppUpdateRepository(
-            apiUrl = server.url("/releases").toString(),
-            currentVersionCode = 1,
-        )
-        assertEquals(UpdateState.UpToDate, repo.getUpdateState())
+        assertEquals(UpdateState.UpToDate, repo(1).getUpdateState())
     }
 }


### PR DESCRIPTION
## Summary

- Adds an optional `CoroutineDispatcher` parameter (defaulting to `Dispatchers.IO`) to `HttpAppUpdateRepository`, `httpRssFeedFetcher`, and `jsoupArticleContentFetcher`
- Tests now pass `UnconfinedTestDispatcher(testScheduler)` so execution runs under the coroutine test scheduler instead of blocking on real IO threads
- `AppUpdateRepositoryTest` refactored to a `TestScope.repo()` helper to share the injected dispatcher across all tests

Closes #120

🤖 Generated with [Claude Code](https://claude.ai/claude-code)