### PR TITLE
[#122] fix: render article images in document order

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContent.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContent.kt
@@ -2,9 +2,13 @@ package com.hopescrolling.data.article
 
 data class ArticleLink(val text: String, val url: String)
 
+sealed class ContentItem {
+    data class Paragraph(val text: String) : ContentItem()
+    data class Image(val url: String) : ContentItem()
+}
+
 data class ArticleContent(
     val title: String,
-    val paragraphs: List<String>,
-    val imageUrls: List<String> = emptyList(),
+    val items: List<ContentItem> = emptyList(),
     val links: List<ArticleLink> = emptyList(),
 )

--- a/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContentFetcher.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContentFetcher.kt
@@ -44,11 +44,20 @@ private class JsoupArticleContentFetcher(
         val doc = Jsoup.parse(html, url)
         val title = doc.title()
         val contentEl = findContentElement(doc)
-        val paragraphs = contentEl.select("p")
-            .map { it.text() }
-            .filter { it.isNotBlank() }
-        val imageUrls = contentEl.select("img[src]")
-            .mapNotNull { it.absUrl("src").takeIf { s -> s.isNotBlank() } }
+        val items = buildList {
+            for (el in contentEl.select("p, img[src]")) {
+                when (el.tagName()) {
+                    "p" -> {
+                        val text = el.text()
+                        if (text.isNotBlank()) add(ContentItem.Paragraph(text))
+                    }
+                    "img" -> {
+                        val src = el.absUrl("src")
+                        if (src.isNotBlank()) add(ContentItem.Image(src))
+                    }
+                }
+            }
+        }
         // Only extract links NOT inside <p> elements — paragraph text already contains their
         // visible text, so including them here would duplicate content for the user.
         val links = contentEl.select("a[href]")
@@ -58,7 +67,7 @@ private class JsoupArticleContentFetcher(
                 val href = el.absUrl("href")
                 if (text.isNotBlank() && href.isNotBlank()) ArticleLink(text, href) else null
             }
-        return ArticleContent(title = title, paragraphs = paragraphs, imageUrls = imageUrls, links = links)
+        return ArticleContent(title = title, items = items, links = links)
     }
 
     private fun findContentElement(doc: Document): Element =

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.hopescrolling.data.article.ContentItem
 import com.hopescrolling.ui.theme.Spacing
 
 @Composable
@@ -61,25 +62,28 @@ fun ArticleReaderScreen(viewModel: ArticleReaderViewModel) {
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.testTag("reader_title"),
                 )
-                state.content.imageUrls.forEachIndexed { index, imageUrl ->
-                    // heightIn(min=1.dp) prevents AsyncImage from collapsing to zero size
-                    // before the image loads, which would make the node fail assertIsDisplayed()
-                    AsyncImage(
-                        model = imageUrl,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 1.dp)
-                            .testTag("reader_image_$index"),
-                    )
-                }
-                state.content.paragraphs.forEachIndexed { index, paragraph ->
-                    Text(
-                        text = paragraph,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.testTag("reader_paragraph_$index"),
-                    )
+                // Local vars reset to 0 each composition pass — safe, not captured across recompositions.
+                var imageCount = 0
+                var paraCount = 0
+                state.content.items.forEach { item ->
+                    when (item) {
+                        is ContentItem.Image -> AsyncImage(
+                            model = item.url,
+                            contentDescription = null,
+                            // heightIn(min=1.dp) prevents AsyncImage from collapsing to zero size
+                            // before the image loads, which would make the node fail assertIsDisplayed()
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = 1.dp)
+                                .testTag("reader_image_${imageCount++}"),
+                        )
+                        is ContentItem.Paragraph -> Text(
+                            text = item.text,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.testTag("reader_paragraph_${paraCount++}"),
+                        )
+                    }
                 }
                 state.content.links.forEachIndexed { index, link ->
                     TextButton(

--- a/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
@@ -2,7 +2,13 @@ package com.hopescrolling
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
 import androidx.activity.ComponentActivity
+import androidx.test.core.app.ApplicationProvider
+import coil.Coil
+import coil.ImageLoader
+import coil.test.FakeImageLoaderEngine
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -19,6 +25,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToIndex
 import com.hopescrolling.data.article.ArticleContent
+import com.hopescrolling.data.article.ContentItem
 import com.hopescrolling.data.article.httpRssFeedFetcher
 import com.hopescrolling.data.feed.FeedSource
 import com.hopescrolling.data.rss.DefaultRssParser
@@ -75,10 +82,22 @@ class ScreenshotTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Before
-    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val placeholder = Bitmap.createBitmap(720, 300, Bitmap.Config.ARGB_8888)
+            .also { Canvas(it).drawColor(Color.DKGRAY) }
+        val engine = FakeImageLoaderEngine.Builder()
+            .default(BitmapDrawable(context.resources, placeholder))
+            .build()
+        Coil.setImageLoader(ImageLoader.Builder(context).components { add(engine) }.build())
+    }
 
     @After
-    fun tearDown() = Dispatchers.resetMain()
+    fun tearDown() {
+        Dispatchers.resetMain()
+        Coil.reset()
+    }
 
     private fun saveScreenshot(name: String) {
         composeTestRule.waitForIdle()
@@ -230,10 +249,11 @@ class ScreenshotTest {
     fun screenshot_articleReaderScreen_success() {
         val content = ArticleContent(
             title = "Kotlin 2.2 Brings Improved Type Inference",
-            paragraphs = listOf(
-                "The latest Kotlin release ships smarter type inference and faster incremental compilation, making large codebases feel snappier during development.",
-                "Among the most anticipated improvements is context-sensitive overload resolution, which reduces the need for explicit type annotations in common patterns.",
-                "The Kotlin team has also invested in tooling: IDE plugins now surface type-inference hints inline, helping developers understand why a particular overload was chosen.",
+            items = listOf(
+                ContentItem.Paragraph("The latest Kotlin release ships smarter type inference and faster incremental compilation, making large codebases feel snappier during development."),
+                ContentItem.Image("https://example.com/kotlin-inference.png"),
+                ContentItem.Paragraph("Among the most anticipated improvements is context-sensitive overload resolution, which reduces the need for explicit type annotations in common patterns."),
+                ContentItem.Paragraph("The Kotlin team has also invested in tooling: IDE plugins now surface type-inference hints inline, helping developers understand why a particular overload was chosen."),
             ),
         )
         val viewModel = ArticleReaderViewModel(

--- a/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import com.hopescrolling.data.article.ContentItem
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ArticleContentFetcherTest {
@@ -65,7 +66,7 @@ class ArticleContentFetcherTest {
         val result = jsoupArticleContentFetcher().fetch(server.url("/").toString())
 
         val content = result.getOrThrow()
-        assertTrue(content.paragraphs.contains(longText))
+        assertTrue(content.items.filterIsInstance<ContentItem.Paragraph>().any { it.text == longText })
     }
 
     @Test
@@ -82,7 +83,7 @@ class ArticleContentFetcherTest {
         val result = jsoupArticleContentFetcher().fetch(server.url("/").toString())
 
         val content = result.getOrThrow()
-        assertEquals(listOf("Main content"), content.paragraphs)
+        assertEquals(listOf(ContentItem.Paragraph("Main content")), content.items)
     }
 
     @Test
@@ -99,7 +100,7 @@ class ArticleContentFetcherTest {
         val result = jsoupArticleContentFetcher().fetch(server.url("/").toString())
 
         val content = result.getOrThrow()
-        assertEquals(listOf("Main role content"), content.paragraphs)
+        assertEquals(listOf(ContentItem.Paragraph("Main role content")), content.items)
     }
 
     @Test
@@ -115,7 +116,7 @@ class ArticleContentFetcherTest {
         val result = jsoupArticleContentFetcher().fetch(server.url("/").toString())
 
         val content = result.getOrThrow()
-        assertEquals(listOf("Article content"), content.paragraphs)
+        assertEquals(listOf(ContentItem.Paragraph("Article content")), content.items)
     }
 
     @Test
@@ -151,7 +152,15 @@ class ArticleContentFetcherTest {
 
         val content = jsoupArticleContentFetcher().fetch(server.url("/").toString()).getOrThrow()
 
-        assertEquals(listOf("https://example.com/photo.jpg", "https://example.com/chart.png"), content.imageUrls)
+        assertEquals(
+            listOf(
+                ContentItem.Paragraph("First para"),
+                ContentItem.Image("https://example.com/photo.jpg"),
+                ContentItem.Paragraph("Second para"),
+                ContentItem.Image("https://example.com/chart.png"),
+            ),
+            content.items,
+        )
     }
 
     @Test
@@ -167,6 +176,29 @@ class ArticleContentFetcherTest {
         assertTrue(result.isSuccess)
         val content = result.getOrThrow()
         assertEquals("My Article", content.title)
-        assertEquals(listOf("First para", "Second para"), content.paragraphs)
+        assertEquals(listOf(ContentItem.Paragraph("First para"), ContentItem.Paragraph("Second para")), content.items)
+    }
+
+    @Test
+    fun `preserves document order of paragraphs and images`() = runTest {
+        val html = """
+            <html><body><article>
+                <p>First para</p>
+                <img src="https://example.com/photo.jpg"/>
+                <p>Second para</p>
+            </article></body></html>
+        """.trimIndent()
+        server.enqueue(MockResponse().setBody(html).setResponseCode(200))
+
+        val content = jsoupArticleContentFetcher().fetch(server.url("/").toString()).getOrThrow()
+
+        assertEquals(
+            listOf(
+                ContentItem.Paragraph("First para"),
+                ContentItem.Image("https://example.com/photo.jpg"),
+                ContentItem.Paragraph("Second para"),
+            ),
+            content.items,
+        )
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
@@ -13,6 +13,7 @@ import coil.Coil
 import coil.ImageLoader
 import coil.test.FakeImageLoaderEngine
 import com.hopescrolling.data.article.ArticleContent
+import com.hopescrolling.data.article.ContentItem
 import com.hopescrolling.util.FakeArticleContentFetcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -68,7 +69,7 @@ class ArticleReaderScreenTest {
 
         val content = ArticleContent(
             title = "Article",
-            paragraphs = listOf("Para"),
+            items = listOf(ContentItem.Paragraph("Para")),
             links = listOf(com.hopescrolling.data.article.ArticleLink("A link", "https://example.com/ref")),
         )
         val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(Result.success(content)), "https://example.com")
@@ -83,7 +84,7 @@ class ArticleReaderScreenTest {
     fun readerScreen_showsLinksAsClickable() {
         val content = ArticleContent(
             title = "Article with links",
-            paragraphs = listOf("Para"),
+            items = listOf(ContentItem.Paragraph("Para")),
             links = listOf(
                 com.hopescrolling.data.article.ArticleLink("Reference 1", "https://example.com/ref1"),
                 com.hopescrolling.data.article.ArticleLink("Reference 2", "https://example.com/ref2"),
@@ -101,8 +102,11 @@ class ArticleReaderScreenTest {
     fun readerScreen_showsImagesOnSuccess() {
         val content = ArticleContent(
             title = "Article with images",
-            paragraphs = listOf("Para"),
-            imageUrls = listOf("https://example.com/photo.jpg", "https://example.com/chart.png"),
+            items = listOf(
+                ContentItem.Paragraph("Para"),
+                ContentItem.Image("https://example.com/photo.jpg"),
+                ContentItem.Image("https://example.com/chart.png"),
+            ),
         )
         val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(Result.success(content)), "https://example.com")
         composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
@@ -113,7 +117,7 @@ class ArticleReaderScreenTest {
 
     @Test
     fun readerScreen_showsTitleAndParagraphsOnSuccess() {
-        val content = ArticleContent(title = "Great Article", paragraphs = listOf("First paragraph.", "Second paragraph."))
+        val content = ArticleContent(title = "Great Article", items = listOf(ContentItem.Paragraph("First paragraph."), ContentItem.Paragraph("Second paragraph.")))
         val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(Result.success(content)), "https://example.com")
         composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
 
@@ -129,5 +133,23 @@ class ArticleReaderScreenTest {
         composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("reader_loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun readerScreen_rendersImagesInDocumentOrder() {
+        val content = ArticleContent(
+            title = "Mixed",
+            items = listOf(
+                ContentItem.Paragraph("First para"),
+                ContentItem.Image("https://example.com/photo.jpg"),
+                ContentItem.Paragraph("Second para"),
+            ),
+        )
+        val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(Result.success(content)), "https://example.com")
+        composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("reader_paragraph_0").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("reader_image_0").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("reader_paragraph_1").assertIsDisplayed()
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.hopescrolling.ui.screens
 
 import com.hopescrolling.data.article.ArticleContent
+import com.hopescrolling.data.article.ContentItem
 import com.hopescrolling.util.FakeArticleContentFetcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -37,7 +38,7 @@ class ArticleReaderViewModelTest {
 
     @Test
     fun `uiState emits Success with content after successful fetch`() = runTest {
-        val content = ArticleContent(title = "My Title", paragraphs = listOf("Para 1", "Para 2"))
+        val content = ArticleContent(title = "My Title", items = listOf(ContentItem.Paragraph("Para 1"), ContentItem.Paragraph("Para 2")))
         val viewModel = ArticleReaderViewModel(
             FakeArticleContentFetcher(Result.success(content)),
             "https://example.com/article",

--- a/app/src/test/kotlin/com/hopescrolling/util/FakeArticleContentFetcher.kt
+++ b/app/src/test/kotlin/com/hopescrolling/util/FakeArticleContentFetcher.kt
@@ -2,11 +2,12 @@ package com.hopescrolling.util
 
 import com.hopescrolling.data.article.ArticleContent
 import com.hopescrolling.data.article.ArticleContentFetcher
+import com.hopescrolling.data.article.ContentItem
 import kotlinx.coroutines.awaitCancellation
 
 class FakeArticleContentFetcher(
     private val result: Result<ArticleContent>? = Result.success(
-        ArticleContent(title = "Test Title", paragraphs = listOf("Test paragraph")),
+        ArticleContent(title = "Test Title", items = listOf(ContentItem.Paragraph("Test paragraph"))),
     ),
 ) : ArticleContentFetcher {
     override suspend fun fetch(url: String): Result<ArticleContent> =


### PR DESCRIPTION
## Summary

- Replaces separate `paragraphs: List<String>` and `imageUrls: List<String>` in `ArticleContent` with a unified `items: List<ContentItem>` (sealed class: `Paragraph` | `Image`)
- `ArticleContentFetcher` now walks the DOM with a single `select("p, img[src]")` selector, preserving document order
- `ArticleReaderScreen` iterates `items` in a single loop so images render between the paragraphs they belong to, not all at the top

Fixes #122.

## Test plan

- [ ] New fetcher test: `preserves document order of paragraphs and images`
- [ ] New screen test: `readerScreen_rendersImagesInDocumentOrder`
- [ ] All existing fetcher/screen/viewmodel tests updated to use the new `ContentItem` model
- [ ] Screenshot `article_reader_success.png` shows image placeholder between first and second paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)