### PR TITLE
[#99] fix: render links in document order instead of pushing to bottom

### DIFF
--- a/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContent.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContent.kt
@@ -1,14 +1,12 @@
 package com.hopescrolling.data.article
 
-data class ArticleLink(val text: String, val url: String)
-
 sealed class ContentItem {
     data class Paragraph(val text: String) : ContentItem()
     data class Image(val url: String) : ContentItem()
+    data class Link(val text: String, val url: String) : ContentItem()
 }
 
 data class ArticleContent(
     val title: String,
     val items: List<ContentItem> = emptyList(),
-    val links: List<ArticleLink> = emptyList(),
 )

--- a/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContentFetcher.kt
+++ b/app/src/main/kotlin/com/hopescrolling/data/article/ArticleContentFetcher.kt
@@ -45,7 +45,7 @@ private class JsoupArticleContentFetcher(
         val title = doc.title()
         val contentEl = findContentElement(doc)
         val items = buildList {
-            for (el in contentEl.select("p, img[src]")) {
+            for (el in contentEl.select("p, img[src], a[href]")) {
                 when (el.tagName()) {
                     "p" -> {
                         val text = el.text()
@@ -55,19 +55,17 @@ private class JsoupArticleContentFetcher(
                         val src = el.absUrl("src")
                         if (src.isNotBlank()) add(ContentItem.Image(src))
                     }
+                    "a" -> {
+                        if (el.parents().none { it.tagName() == "p" } && el.select("img").isEmpty()) {
+                            val text = el.text().trim()
+                            val href = el.absUrl("href")
+                            if (text.isNotBlank() && href.isNotBlank()) add(ContentItem.Link(text, href))
+                        }
+                    }
                 }
             }
         }
-        // Only extract links NOT inside <p> elements — paragraph text already contains their
-        // visible text, so including them here would duplicate content for the user.
-        val links = contentEl.select("a[href]")
-            .filter { el -> el.parents().none { it.tagName() == "p" } }
-            .mapNotNull { el ->
-                val text = el.text().trim()
-                val href = el.absUrl("href")
-                if (text.isNotBlank() && href.isNotBlank()) ArticleLink(text, href) else null
-            }
-        return ArticleContent(title = title, items = items, links = links)
+        return ArticleContent(title = title, items = items)
     }
 
     private fun findContentElement(doc: Document): Element =

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreen.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreen.kt
@@ -65,6 +65,7 @@ fun ArticleReaderScreen(viewModel: ArticleReaderViewModel) {
                 // Local vars reset to 0 each composition pass — safe, not captured across recompositions.
                 var imageCount = 0
                 var paraCount = 0
+                var linkCount = 0
                 state.content.items.forEach { item ->
                     when (item) {
                         is ContentItem.Image -> AsyncImage(
@@ -83,20 +84,18 @@ fun ArticleReaderScreen(viewModel: ArticleReaderViewModel) {
                             color = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.testTag("reader_paragraph_${paraCount++}"),
                         )
-                    }
-                }
-                state.content.links.forEachIndexed { index, link ->
-                    TextButton(
-                        onClick = { openInBrowser(context, link.url) },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .testTag("reader_link_$index"),
-                    ) {
-                        Text(
-                            text = link.text,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
+                        is ContentItem.Link -> TextButton(
+                            onClick = { openInBrowser(context, item.url) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("reader_link_${linkCount++}"),
+                        ) {
+                            Text(
+                                text = item.text,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ScreenshotTest.kt
@@ -291,6 +291,52 @@ class ScreenshotTest {
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Test
+    fun screenshot_articleReaderScreen_contentOrder() {
+        val content = ArticleContent(
+            title = "Document Order: Paragraphs, Links, and Images",
+            items = listOf(
+                ContentItem.Paragraph("This paragraph appears first. It introduces the topic before the link below."),
+                ContentItem.Link("Read the full specification", "https://example.com/spec"),
+                ContentItem.Paragraph("This paragraph appears after the link but before the image."),
+                ContentItem.Image("https://example.com/diagram.png"),
+                ContentItem.Paragraph("This paragraph appears after the image, at the end of the article."),
+            ),
+        )
+        val viewModel = ArticleReaderViewModel(
+            FakeArticleContentFetcher(Result.success(content)),
+            "https://example.com/article",
+        )
+        composeTestRule.setContent {
+            HopescrollingTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = {},
+                            navigationIcon = {
+                                IconButton(onClick = {}) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                }
+                            },
+                            actions = {
+                                IconButton(onClick = {}) {
+                                    Icon(Icons.Default.Share, contentDescription = "Open in browser")
+                                }
+                            },
+                        )
+                    },
+                ) { padding ->
+                    Box(modifier = Modifier.padding(padding)) {
+                        ArticleReaderScreen(viewModel = viewModel)
+                    }
+                }
+            }
+        }
+        saveScreenshot("article_reader_content_order")
+        assertTrue(File(screenshotsDir, "article_reader_content_order.png").exists())
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
     fun screenshot_articleReaderScreen_error() {
         val viewModel = ArticleReaderViewModel(
             FakeArticleContentFetcher(Result.failure(RuntimeException("Failed to load article"))),

--- a/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/data/article/ArticleContentFetcherTest.kt
@@ -134,7 +134,14 @@ class ArticleContentFetcherTest {
         val content = jsoupArticleContentFetcher().fetch(server.url("/").toString()).getOrThrow()
 
         // Inline links (inside <p>) are excluded to avoid duplicating paragraph text
-        assertEquals(listOf("Standalone Link 1" to "https://example.com/standalone1", "Standalone Link 2" to "https://example.com/standalone2"), content.links.map { it.text to it.url })
+        assertEquals(
+            listOf(
+                ContentItem.Paragraph("See inline link in this paragraph."),
+                ContentItem.Link("Standalone Link 1", "https://example.com/standalone1"),
+                ContentItem.Link("Standalone Link 2", "https://example.com/standalone2"),
+            ),
+            content.items,
+        )
     }
 
     @Test
@@ -177,6 +184,52 @@ class ArticleContentFetcherTest {
         val content = result.getOrThrow()
         assertEquals("My Article", content.title)
         assertEquals(listOf(ContentItem.Paragraph("First para"), ContentItem.Paragraph("Second para")), content.items)
+    }
+
+    @Test
+    fun `preserves document order of paragraphs images and links`() = runTest {
+        val html = """
+            <html><body><article>
+                <p>First para</p>
+                <a href="https://example.com/link1">A Link</a>
+                <p>Second para</p>
+            </article></body></html>
+        """.trimIndent()
+        server.enqueue(MockResponse().setBody(html).setResponseCode(200))
+
+        val content = jsoupArticleContentFetcher().fetch(server.url("/").toString()).getOrThrow()
+
+        assertEquals(
+            listOf(
+                ContentItem.Paragraph("First para"),
+                ContentItem.Link("A Link", "https://example.com/link1"),
+                ContentItem.Paragraph("Second para"),
+            ),
+            content.items,
+        )
+    }
+
+    @Test
+    fun `does not emit link for image-wrapping anchor`() = runTest {
+        val html = """
+            <html><body><article>
+                <p>Before</p>
+                <a href="https://example.com/photo"><img src="https://example.com/photo.jpg"/></a>
+                <p>After</p>
+            </article></body></html>
+        """.trimIndent()
+        server.enqueue(MockResponse().setBody(html).setResponseCode(200))
+
+        val content = jsoupArticleContentFetcher().fetch(server.url("/").toString()).getOrThrow()
+
+        assertEquals(
+            listOf(
+                ContentItem.Paragraph("Before"),
+                ContentItem.Image("https://example.com/photo.jpg"),
+                ContentItem.Paragraph("After"),
+            ),
+            content.items,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/ArticleReaderScreenTest.kt
@@ -69,8 +69,10 @@ class ArticleReaderScreenTest {
 
         val content = ArticleContent(
             title = "Article",
-            items = listOf(ContentItem.Paragraph("Para")),
-            links = listOf(com.hopescrolling.data.article.ArticleLink("A link", "https://example.com/ref")),
+            items = listOf(
+                ContentItem.Paragraph("Para"),
+                ContentItem.Link("A link", "https://example.com/ref"),
+            ),
         )
         val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(Result.success(content)), "https://example.com")
         composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
@@ -84,10 +86,10 @@ class ArticleReaderScreenTest {
     fun readerScreen_showsLinksAsClickable() {
         val content = ArticleContent(
             title = "Article with links",
-            items = listOf(ContentItem.Paragraph("Para")),
-            links = listOf(
-                com.hopescrolling.data.article.ArticleLink("Reference 1", "https://example.com/ref1"),
-                com.hopescrolling.data.article.ArticleLink("Reference 2", "https://example.com/ref2"),
+            items = listOf(
+                ContentItem.Paragraph("Para"),
+                ContentItem.Link("Reference 1", "https://example.com/ref1"),
+                ContentItem.Link("Reference 2", "https://example.com/ref2"),
             ),
         )
         val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(Result.success(content)), "https://example.com")
@@ -133,6 +135,25 @@ class ArticleReaderScreenTest {
         composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
 
         composeTestRule.onNodeWithTag("reader_loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun readerScreen_rendersLinksInDocumentOrder() {
+        val content = ArticleContent(
+            title = "Mixed",
+            items = listOf(
+                ContentItem.Paragraph("First para"),
+                ContentItem.Link("A Link", "https://example.com/link1"),
+                ContentItem.Paragraph("Second para"),
+            ),
+        )
+        val viewModel = ArticleReaderViewModel(FakeArticleContentFetcher(Result.success(content)), "https://example.com")
+        composeTestRule.setContent { ArticleReaderScreen(viewModel = viewModel) }
+
+        composeTestRule.onNodeWithTag("reader_paragraph_0").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("reader_link_0").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("reader_link_0").assertHasClickAction()
+        composeTestRule.onNodeWithTag("reader_paragraph_1").assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `ContentItem.Link` to the sealed class so links can be interleaved with paragraphs and images in `items`
- Updates `ArticleContentFetcher` to include `a[href]` in the Jsoup selector, placing standalone links in document order; excludes links inside `<p>` (duplicate text) and bare image-wrapping anchors
- Removes the now-dead `ArticleLink` class, `links` field on `ArticleContent`, and the trailing link render block in `ArticleReaderScreen`

## Test plan

- [ ] `ArticleContentFetcherTest`: `preserves document order of paragraphs images and links`, `extracts standalone links not inside paragraphs`, `does not emit link for image-wrapping anchor`
- [ ] `ArticleReaderScreenTest`: `readerScreen_rendersLinksInDocumentOrder`, `readerScreen_showsLinksAsClickable`, `readerScreen_showsToastWhenNoBrowserAppFound`
- [ ] `ScreenshotTest`: `screenshot_articleReaderScreen_contentOrder` — visually confirms para → link → para → image → para order

Closes #99
Related: #134 (links inside `<li>` / `<blockquote>` — pre-existing, tracked separately)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)