### PR TITLE
[#41, #79] refactor: derive TimelineViewModel.uiState atomically via combine()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,20 @@ After every commit, launch a subagent to review it (`git show HEAD`) and report 
 
 Every finding raised by the reviewer must be either fixed (in the current commit via amend) or tracked as a GitHub issue. Do not silently ignore reviewer findings. If the finding was introduced by this commit, fix it directly via amend. If it is pre-existing, fix it now only if the change is small and safe — otherwise file an issue for later.
 
+## TDD
+
+Always implement with strict TDD — one behavior at a time, test before code:
+
+1. Write one failing test for the next behavior (RED) — run it and confirm it fails
+2. Write the minimal code to make it pass (GREEN)
+3. Repeat for the next behavior
+
+Never write all tests first then all implementation (horizontal slicing). Each test must respond to what you learned from the previous cycle.
+
+Tests verify behavior through public interfaces only — not implementation details, not private methods. A test that breaks when you rename an internal function is testing the wrong thing.
+
+When working with OpenSpec, use the `spec-driven-custom` schema (not `spec-driven`) so tasks are generated with [RED]/[GREEN] pairs already structured correctly.
+
 ## Commands
 
 `gradlew` is patched to fall back to Android Studio's JDK when `JAVA_HOME` is not set — no `JAVA_HOME` export needed locally. `org.gradle.java.home` is intentionally absent from `gradle.properties` so CI can use its own JDK.

--- a/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/hopescrolling/ui/screens/TimelineViewModel.kt
@@ -5,10 +5,13 @@ import androidx.lifecycle.viewModelScope
 import com.hopescrolling.data.article.ArticleRepository
 import com.hopescrolling.data.readstate.ReadStateRepository
 import com.hopescrolling.data.rss.Article
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -19,34 +22,47 @@ data class TimelineUiState(
     val readIds: Set<String> = emptySet(),
 )
 
+private data class ArticlesLoadState(
+    val articles: List<Article> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null,
+)
+
 class TimelineViewModel(
     private val repository: ArticleRepository,
     private val readStateRepository: ReadStateRepository,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(TimelineUiState())
-    val uiState: StateFlow<TimelineUiState> = _uiState.asStateFlow()
+    private val _articlesState = MutableStateFlow(ArticlesLoadState())
+
+    val uiState: StateFlow<TimelineUiState> = combine(
+        _articlesState,
+        readStateRepository.getReadIds(),
+    ) { articlesState, readIds ->
+        TimelineUiState(
+            articles = articlesState.articles,
+            isLoading = articlesState.isLoading,
+            error = articlesState.error,
+            readIds = readIds,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, TimelineUiState())
 
     private var fetchJob: Job? = null
 
     init {
-        viewModelScope.launch {
-            readStateRepository.getReadIds().collect { readIds ->
-                _uiState.update { it.copy(readIds = readIds) }
-            }
-        }
         refresh()
     }
 
     fun refresh() {
         fetchJob?.cancel()
-        _uiState.update { it.copy(isLoading = true, error = null) }
+        _articlesState.update { it.copy(isLoading = true, error = null) }
         fetchJob = viewModelScope.launch {
             runCatching { repository.getArticles() }
                 .onSuccess { articles ->
-                    _uiState.update { it.copy(articles = articles, isLoading = false, error = null) }
+                    _articlesState.update { it.copy(articles = articles, isLoading = false, error = null) }
                 }
                 .onFailure { e ->
-                    _uiState.update {
+                    if (e is CancellationException) throw e
+                    _articlesState.update {
                         it.copy(
                             isLoading = false,
                             error = e.message ?: e::class.simpleName ?: "Unknown error",

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineScreenTest.kt
@@ -210,11 +210,13 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
         )
-        val repo = FakeArticleRepository(articles = articles)
+        // hangAfterCalls=1: init fetch completes, subsequent refresh hangs so loading state persists
+        val repo = FakeArticleRepository(articles = articles, hangAfterCalls = 1)
         val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
         dispatcher.scheduler.advanceUntilIdle() // complete initial load so articles are present
 
         viewModel.refresh() // isLoading=true while articles are already in state
+        dispatcher.scheduler.runCurrent() // run combine() reaction; refresh fetch suspends
 
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
         // uiState.isLoading == true confirms PullToRefreshBox receives isRefreshing=true (the wiring)
@@ -230,11 +232,13 @@ class TimelineScreenTest {
         val articles = listOf(
             Article(title = "Existing Post", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
         )
-        val repo = FakeArticleRepository(articles = articles)
+        // hangAfterCalls=1: init fetch completes, subsequent refresh hangs so loading state persists
+        val repo = FakeArticleRepository(articles = articles, hangAfterCalls = 1)
         val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
         dispatcher.scheduler.advanceUntilIdle() // complete initial load
 
         viewModel.refresh() // isLoading=true but articles already present
+        dispatcher.scheduler.runCurrent() // run combine() reaction; refresh fetch suspends
 
         composeTestRule.setContent { TimelineScreen(viewModel = viewModel) }
         composeTestRule.onNodeWithText("Existing Post").assertIsDisplayed()

--- a/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
+++ b/app/src/test/kotlin/com/hopescrolling/ui/screens/TimelineViewModelTest.kt
@@ -75,11 +75,13 @@ class TimelineViewModelTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         Dispatchers.setMain(testDispatcher)
         try {
-            val repo = FakeArticleRepository()
+            // hangAfterCalls=1: init fetch completes, subsequent refresh hangs
+            val repo = FakeArticleRepository(hangAfterCalls = 1)
             val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
             testScheduler.advanceUntilIdle() // complete init fetch
 
             viewModel.refresh()
+            testScheduler.runCurrent() // run combine() reaction; refresh fetch suspends
 
             assertEquals(true, viewModel.uiState.value.isLoading)
             assertEquals(null, viewModel.uiState.value.error)
@@ -109,7 +111,7 @@ class TimelineViewModelTest {
     fun `uiState readIds is empty when no articles have been read`() = runTest {
         val viewModel = TimelineViewModel(FakeArticleRepository(), FakeReadStateRepository())
 
-        val state = viewModel.uiState.first()
+        val state = viewModel.uiState.first { !it.isLoading }
 
         assertEquals(emptySet<String>(), state.readIds)
     }
@@ -121,5 +123,92 @@ class TimelineViewModelTest {
         viewModel.markRead("https://a.com/1")
 
         assertEquals(setOf("https://a.com/1"), viewModel.uiState.value.readIds)
+    }
+
+    @Test
+    fun `uiState has error set and readIds unchanged when repository throws`() = runTest {
+        val readStateRepo = FakeReadStateRepository(initialReadIds = setOf("id1"))
+        val viewModel = TimelineViewModel(
+            FakeArticleRepository(error = RuntimeException("oops")),
+            readStateRepo,
+        )
+
+        val state = viewModel.uiState.first { !it.isLoading }
+
+        assertEquals("oops", state.error)
+        assertEquals(setOf("id1"), state.readIds)
+    }
+
+    @Test
+    fun `readIds updates while loading are reflected in uiState without skipping`() = runTest {
+        val readStateRepo = FakeReadStateRepository()
+        // hangAfterCalls=0: fetch always hangs so isLoading stays true
+        val viewModel = TimelineViewModel(FakeArticleRepository(hangAfterCalls = 0), readStateRepo)
+
+        // UnconfinedTestDispatcher + SharingStarted.Eagerly makes combine() propagate synchronously
+        readStateRepo.markRead("id1")
+        assertEquals(setOf("id1"), viewModel.uiState.value.readIds)
+        assertEquals(true, viewModel.uiState.value.isLoading)
+
+        readStateRepo.markRead("id2")
+        assertEquals(setOf("id1", "id2"), viewModel.uiState.value.readIds)
+        assertEquals(true, viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `uiState readIds is preserved during refresh`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            val readStateRepo = FakeReadStateRepository(initialReadIds = setOf("id1"))
+            // hangAfterCalls=1: init fetch completes, explicit refresh hangs
+            val viewModel = TimelineViewModel(FakeArticleRepository(hangAfterCalls = 1), readStateRepo)
+            testScheduler.advanceUntilIdle() // init fetch completes
+
+            viewModel.refresh()
+            testScheduler.runCurrent() // combine() reacts to isLoading=true; refresh fetch suspends
+
+            assertEquals(true, viewModel.uiState.value.isLoading)
+            assertEquals(setOf("id1"), viewModel.uiState.value.readIds)
+        } finally {
+            Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        }
+    }
+
+    @Test
+    fun `refresh while fetching cancels previous fetch without setting an error`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            // hangAfterCalls=0: every fetch hangs, so refresh() always cancels the previous one
+            val viewModel = TimelineViewModel(FakeArticleRepository(hangAfterCalls = 0), FakeReadStateRepository())
+            testScheduler.runCurrent() // combine() emits initial state; fetch suspends
+
+            viewModel.refresh() // cancel hanging fetch; start a new hanging fetch
+            testScheduler.runCurrent() // deliver CancellationException to cancelled fetch; start new one
+
+            assertEquals(null, viewModel.uiState.value.error)
+            assertEquals(true, viewModel.uiState.value.isLoading)
+        } finally {
+            Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        }
+    }
+
+    @Test
+    fun `successful refresh after error clears error state`() = runTest {
+        val articles = listOf(
+            Article(title = "Recovered", link = "https://a.com/1", description = null, pubDate = null, feedSourceId = "f1"),
+        )
+        val repo = FakeArticleRepository(articles = articles, error = RuntimeException("oops"))
+        val viewModel = TimelineViewModel(repo, FakeReadStateRepository())
+        viewModel.uiState.first { it.error != null } // wait for error state
+
+        // Fix the repo error and refresh
+        repo.clearError()
+        viewModel.refresh()
+        val state = viewModel.uiState.first { !it.isLoading }
+
+        assertEquals(null, state.error)
+        assertEquals(articles, state.articles)
     }
 }

--- a/app/src/test/kotlin/com/hopescrolling/util/FakeArticleRepository.kt
+++ b/app/src/test/kotlin/com/hopescrolling/util/FakeArticleRepository.kt
@@ -2,17 +2,26 @@ package com.hopescrolling.util
 
 import com.hopescrolling.data.article.ArticleRepository
 import com.hopescrolling.data.rss.Article
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 class FakeArticleRepository(
     private val articles: List<Article> = emptyList(),
-    private val error: Throwable? = null,
+    error: Throwable? = null,
+    private val hangAfterCalls: Int = Int.MAX_VALUE,
 ) : ArticleRepository {
     var callCount = 0
         private set
 
+    private var error: Throwable? = error
+
+    fun clearError() {
+        error = null
+    }
+
     override suspend fun getArticles(): List<Article> {
         callCount++
-        if (error != null) throw error
+        if (callCount > hangAfterCalls) suspendCancellableCoroutine<Nothing> { }
+        error?.let { throw it }
         return articles
     }
 }

--- a/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-custom
+created: 2026-04-26

--- a/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/design.md
+++ b/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`TimelineViewModel` currently manages two independent coroutine jobs in `init`: one that collects `readStateRepository.getReadIds()` and one launched by `refresh()` that calls `articleRepository.getArticles()`. Both jobs write to the same `MutableStateFlow<TimelineUiState>` via `update {}`, creating a window where articles and read-state are briefly out of sync. Test setup must carefully order coroutine execution to avoid flakiness.
+
+`ArticleRepository.getArticles()` is a one-shot `suspend fun`, not a `Flow`. `ReadStateRepository.getReadIds()` is a `Flow<Set<String>>`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Merge article and read-state into `TimelineUiState` atomically via `combine()`
+- Eliminate the temporal coupling between the two coroutine jobs
+- Simplify test setup — a single flow collector is enough to observe all state transitions
+- Preserve the `refresh()` trigger model (on-demand fetch, not continuous polling)
+
+**Non-Goals:**
+- Changing `ArticleRepository` to return a `Flow<List<Article>>` — that is a separate interface change with broader impact
+- Supporting optimistic or incremental article updates
+- Any change to `ReadStateRepository`
+
+## Decisions
+
+### Internal `MutableStateFlow` for articles load state
+
+Since `ArticleRepository.getArticles()` is a suspend function, it cannot be directly passed to `combine()`. Instead, introduce a private `_articlesState: MutableStateFlow<ArticlesLoadState>` where `ArticlesLoadState` is a sealed class (or simple data class) holding `articles`, `isLoading`, and `error`.
+
+`refresh()` updates `_articlesState` as it fetches. The public `uiState` is derived by `combine(_articlesState, readStateRepository.getReadIds())` and exposed via `stateIn(SharingStarted.Eagerly)`.
+
+**Alternative considered:** Wrapping each `getArticles()` call in `flow { emit(...) }` and re-subscribing on refresh. Rejected: requires managing subscription lifecycle explicitly and leaks the implementation detail that articles are one-shot.
+
+**Alternative considered:** Changing `ArticleRepository` to `Flow<List<Article>>`. Rejected: out of scope for this change; it would require updating `DefaultArticleRepository`, all its dependencies, and existing tests.
+
+### `stateIn` with `SharingStarted.Eagerly`
+
+The combined flow is turned into a `StateFlow` via `stateIn(viewModelScope, SharingStarted.Eagerly, TimelineUiState())`. `Eagerly` matches the existing behavior (collection starts in `init`, not lazily on first subscriber).
+
+### No `ArticlesLoadState` data class exposed publicly
+
+`ArticlesLoadState` is an internal implementation detail of the ViewModel; it is not part of `TimelineUiState` or any public API.
+
+## Risks / Trade-offs
+
+- [Extra intermediate state object] → Kept private and minimal; does not leak to UI layer
+- [Initial `isLoading = true` must still be the first emitted state] → `stateIn` initial value is `TimelineUiState()` which has `isLoading = true` by default — no change in behavior
+- [Tests that use `uiState.first()` directly] → `stateIn(Eagerly)` ensures the StateFlow is hot from construction; existing test patterns continue to work

--- a/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/proposal.md
+++ b/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`TimelineViewModel` collects from two independent flows with no coordination between them — articles and read-state update shared `MutableStateFlow` state via separate coroutine jobs, creating a window of inconsistency during concurrent updates. Using `combine()` makes the merge explicit and atomic, and simplifies test setup by eliminating the need to sequence two separate collection jobs.
+
+## What Changes
+
+- Replace the dual-coroutine init pattern in `TimelineViewModel` with a single `combine()` on both flows
+- `TimelineUiState` is assembled in one place from a unified combined flow
+- `refresh()` triggers a re-fetch of articles; the combined flow ensures read-state is always in sync
+- Tests can use a single coroutine scope / turbine collector instead of coordinating two separate jobs
+
+## Capabilities
+
+### New Capabilities
+
+- `timeline-flow-coordination`: Atomic merging of article and read-state flows into `TimelineUiState` via `combine()`
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+- `TimelineViewModel` — init block, `refresh()`, internal state management
+- `TimelineUiState` — no structural change, but it is now populated atomically
+- Tests for `TimelineViewModel` — simplified setup; concurrent update scenarios can now be tested reliably

--- a/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/specs/timeline-flow-coordination/spec.md
+++ b/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/specs/timeline-flow-coordination/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Timeline state is assembled atomically from both flows
+`TimelineViewModel` SHALL derive `uiState` by combining the article load state and the read-state flow using `combine()`, so that every emission of `uiState` reflects a consistent snapshot of both sources.
+
+#### Scenario: Both flows emit concurrently
+- **WHEN** the article load state updates while read-state is also updating
+- **THEN** `uiState` SHALL only emit states where articles and readIds are from the same combined snapshot — never a partial mix of old and new values
+
+#### Scenario: Initial state before any fetch
+- **WHEN** `TimelineViewModel` is constructed
+- **THEN** `uiState` SHALL immediately emit `TimelineUiState(isLoading = true, articles = emptyList(), readIds = emptySet())`
+
+### Requirement: Refresh triggers a new article fetch without disrupting read-state observation
+`TimelineViewModel.refresh()` SHALL cancel any in-progress article fetch, set `isLoading = true`, and re-fetch articles — while the read-state flow continues uninterrupted.
+
+#### Scenario: Refresh while read-state has items
+- **WHEN** `readIds` contains one or more IDs and `refresh()` is called
+- **THEN** `uiState` during loading SHALL still reflect the current `readIds` (not reset to empty)
+
+#### Scenario: Successful refresh
+- **WHEN** `refresh()` completes successfully
+- **THEN** `uiState` SHALL emit `isLoading = false` with the newly fetched articles and the current `readIds`
+
+### Requirement: Article fetch errors are surfaced without affecting read-state
+When `ArticleRepository.getArticles()` throws, `TimelineViewModel` SHALL update `uiState.error` and set `isLoading = false`, while `readIds` retains its current value.
+
+#### Scenario: Repository throws during refresh
+- **WHEN** `ArticleRepository.getArticles()` throws a `RuntimeException`
+- **THEN** `uiState` SHALL emit `isLoading = false`, `error` set to the exception message, and `readIds` unchanged
+
+### Requirement: Marking an article read updates uiState.readIds
+Calling `markRead(articleId)` SHALL persist the ID via `ReadStateRepository` and the combined flow SHALL propagate the updated `readIds` into the next `uiState` emission.
+
+#### Scenario: Mark a single article read
+- **WHEN** `markRead("some-id")` is called
+- **THEN** `uiState.readIds` SHALL contain `"some-id"` in the next emission

--- a/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/tasks.md
+++ b/openspec/changes/archive/2026-04-26-coordinate-timeline-flows/tasks.md
@@ -1,0 +1,14 @@
+## 1. Internal ArticlesLoadState
+
+- [x] 1.1 [RED] Write failing test: uiState readIds is preserved during refresh (readIds non-empty while isLoading is true)
+- [x] 1.2 [GREEN] Introduce private `ArticlesLoadState` data class and `_articlesState: MutableStateFlow<ArticlesLoadState>`; derive `uiState` via `combine(_articlesState, readStateRepository.getReadIds())` using `stateIn(Eagerly)`; update `refresh()` and remove old `_uiState` writes
+
+## 2. Atomic state assembly
+
+- [x] 2.1 [RED] Write failing test: articles and readIds are never observed in inconsistent state — emit multiple readIds values via FakeReadStateRepository while articles are loading; assert each collected uiState has internally consistent articles + readIds
+- [x] 2.2 [GREEN] Minimal adjustments to combine() wiring to pass
+
+## 3. Error handling preserves readIds
+
+- [x] 3.1 [RED] Write failing test: when repository throws, uiState has error set and readIds unchanged
+- [x] 3.2 [GREEN] Ensure failure branch in refresh() writes to `_articlesState` (not a separate state flow) so readIds from combine() is always current

--- a/openspec/schemas/spec-driven-custom/schema.yaml
+++ b/openspec/schemas/spec-driven-custom/schema.yaml
@@ -1,0 +1,260 @@
+name: spec-driven-custom
+version: 1
+description: Default OpenSpec workflow - proposal → specs → design → tasks
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Initial proposal document outlining the change
+    template: proposal.md
+    instruction: >
+      Create the proposal document that establishes WHY this change is needed.
+
+
+      Sections:
+
+      - **Why**: 1-2 sentences on the problem or opportunity. What problem does
+      this solve? Why now?
+
+      - **What Changes**: Bullet list of changes. Be specific about new
+      capabilities, modifications, or removals. Mark breaking changes with
+      **BREAKING**.
+
+      - **Capabilities**: Identify which specs will be created or modified:
+        - **New Capabilities**: List capabilities being introduced. Each becomes a new `specs/<name>/spec.md`. Use kebab-case names (e.g., `user-auth`, `data-export`).
+        - **Modified Capabilities**: List existing capabilities whose REQUIREMENTS are changing. Only include if spec-level behavior changes (not just implementation details). Each needs a delta spec file. Check `openspec/specs/` for existing spec names. Leave empty if no requirement changes.
+      - **Impact**: Affected code, APIs, dependencies, or systems.
+
+
+      IMPORTANT: The Capabilities section is critical. It creates the contract
+      between
+
+      proposal and specs phases. Research existing specs before filling this in.
+
+      Each capability listed here will need a corresponding spec file.
+
+
+      Keep it concise (1-2 pages). Focus on the "why" not the "how" -
+
+      implementation details belong in design.md.
+
+
+      This is the foundation - specs, design, and tasks all build on this.
+    requires: []
+  - id: specs
+    generates: specs/**/*.md
+    description: Detailed specifications for the change
+    template: spec.md
+    instruction: >
+      Create specification files that define WHAT the system should do.
+
+
+      Create one spec file per capability listed in the proposal's Capabilities
+      section.
+
+      - New capabilities: use the exact kebab-case name from the proposal
+      (specs/<capability>/spec.md).
+
+      - Modified capabilities: use the existing spec folder name from
+      openspec/specs/<capability>/ when creating the delta spec at
+      specs/<capability>/spec.md.
+
+
+      Delta operations (use ## headers):
+
+      - **ADDED Requirements**: New capabilities
+
+      - **MODIFIED Requirements**: Changed behavior - MUST include full updated
+      content
+
+      - **REMOVED Requirements**: Deprecated features - MUST include **Reason**
+      and **Migration**
+
+      - **RENAMED Requirements**: Name changes only - use FROM:/TO: format
+
+
+      Format requirements:
+
+      - Each requirement: `### Requirement: <name>` followed by description
+
+      - Use SHALL/MUST for normative requirements (avoid should/may)
+
+      - Each scenario: `#### Scenario: <name>` with WHEN/THEN format
+
+      - **CRITICAL**: Scenarios MUST use exactly 4 hashtags (`####`). Using 3
+      hashtags or bullets will fail silently.
+
+      - Every requirement MUST have at least one scenario.
+
+
+      MODIFIED requirements workflow:
+
+      1. Locate the existing requirement in openspec/specs/<capability>/spec.md
+
+      2. Copy the ENTIRE requirement block (from `### Requirement:` through all
+      scenarios)
+
+      3. Paste under `## MODIFIED Requirements` and edit to reflect new behavior
+
+      4. Ensure header text matches exactly (whitespace-insensitive)
+
+
+      Common pitfall: Using MODIFIED with partial content loses detail at
+      archive time.
+
+      If adding new concerns without changing existing behavior, use ADDED
+      instead.
+
+
+      Example:
+
+      ```
+
+      ## ADDED Requirements
+
+
+      ### Requirement: User can export data
+
+      The system SHALL allow users to export their data in CSV format.
+
+
+      #### Scenario: Successful export
+
+      - **WHEN** user clicks "Export" button
+
+      - **THEN** system downloads a CSV file with all user data
+
+
+      ## REMOVED Requirements
+
+
+      ### Requirement: Legacy export
+
+      **Reason**: Replaced by new export system
+
+      **Migration**: Use new export endpoint at /api/v2/export
+
+      ```
+
+
+      Specs should be testable - each scenario is a potential test case.
+    requires:
+      - proposal
+  - id: design
+    generates: design.md
+    description: Technical design document with implementation details
+    template: design.md
+    instruction: >
+      Create the design document that explains HOW to implement the change.
+
+
+      When to include design.md (create only if any apply):
+
+      - Cross-cutting change (multiple services/modules) or new architectural
+      pattern
+
+      - New external dependency or significant data model changes
+
+      - Security, performance, or migration complexity
+
+      - Ambiguity that benefits from technical decisions before coding
+
+
+      Sections:
+
+      - **Context**: Background, current state, constraints, stakeholders
+
+      - **Goals / Non-Goals**: What this design achieves and explicitly excludes
+
+      - **Decisions**: Key technical choices with rationale (why X over Y?).
+      Include alternatives considered for each decision.
+
+      - **Risks / Trade-offs**: Known limitations, things that could go wrong.
+      Format: [Risk] → Mitigation
+
+      - **Migration Plan**: Steps to deploy, rollback strategy (if applicable)
+
+      - **Open Questions**: Outstanding decisions or unknowns to resolve
+
+
+      Focus on architecture and approach, not line-by-line implementation.
+
+      Reference the proposal for motivation and specs for requirements.
+
+
+      Good design docs explain the "why" behind technical decisions.
+    requires:
+      - proposal
+  - id: tasks
+    generates: tasks.md
+    description: Implementation checklist with trackable tasks
+    template: tasks.md
+    instruction: >
+      Create the task list that breaks down the implementation work.
+
+
+      **IMPORTANT: Follow the template below exactly.** The apply phase parses
+
+      checkbox format to track progress. Tasks not using `- [ ]` won't be
+      tracked.
+
+
+      **TDD REQUIREMENT: Tasks MUST follow vertical slices — one behavior at a
+      time, test before implementation. NEVER group all tests together followed
+      by all implementation (horizontal slicing). Each behavior gets a [RED]
+      task immediately followed by a [GREEN] task:**
+
+      - `X.1 [RED] Write failing test for <behavior>`
+
+      - `X.2 [GREEN] Minimal impl to pass`
+
+
+      Guidelines:
+
+      - Group related behaviors under ## numbered headings
+
+      - Each task MUST be a checkbox: `- [ ] X.Y Task description`
+
+      - Tasks should be small enough to complete in one session
+
+      - Order groups by dependency (what must be done first?)
+
+
+      Example:
+
+      ```
+
+      ## 1. User can log in
+
+
+      - [ ] 1.1 [RED] Write failing test: login with valid credentials returns
+      session token
+
+      - [ ] 1.2 [GREEN] Implement login to pass
+
+
+      ## 2. User can log out
+
+
+      - [ ] 2.1 [RED] Write failing test: logout invalidates session token
+
+      - [ ] 2.2 [GREEN] Implement logout to pass
+
+      ```
+
+
+      Reference specs for what needs to be built, design for how to build it.
+
+      Each task should be verifiable - you know when it's done.
+    requires:
+      - specs
+      - design
+apply:
+  requires:
+    - tasks
+  tracks: tasks.md
+  instruction: |
+    Read context files, work through pending tasks, mark complete as you go.
+    For each [RED] task: write the test and run it to confirm it fails before
+    moving to the paired [GREEN] task. For each [GREEN] task: write only enough
+    code to make the current test pass — do not anticipate future tests.
+    Pause if you hit blockers or need clarification.

--- a/openspec/schemas/spec-driven-custom/templates/design.md
+++ b/openspec/schemas/spec-driven-custom/templates/design.md
@@ -1,0 +1,19 @@
+## Context
+
+<!-- Background and current state -->
+
+## Goals / Non-Goals
+
+**Goals:**
+<!-- What this design aims to achieve -->
+
+**Non-Goals:**
+<!-- What is explicitly out of scope -->
+
+## Decisions
+
+<!-- Key design decisions and rationale -->
+
+## Risks / Trade-offs
+
+<!-- Known risks and trade-offs -->

--- a/openspec/schemas/spec-driven-custom/templates/proposal.md
+++ b/openspec/schemas/spec-driven-custom/templates/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+<!-- Explain the motivation for this change. What problem does this solve? Why now? -->
+
+## What Changes
+
+<!-- Describe what will change. Be specific about new capabilities, modifications, or removals. -->
+
+## Capabilities
+
+### New Capabilities
+<!-- Capabilities being introduced. Replace <name> with kebab-case identifier (e.g., user-auth, data-export, api-rate-limiting). Each creates specs/<name>/spec.md -->
+- `<name>`: <brief description of what this capability covers>
+
+### Modified Capabilities
+<!-- Existing capabilities whose REQUIREMENTS are changing (not just implementation).
+     Only list here if spec-level behavior changes. Each needs a delta spec file.
+     Use existing spec names from openspec/specs/. Leave empty if no requirement changes. -->
+- `<existing-name>`: <what requirement is changing>
+
+## Impact
+
+<!-- Affected code, APIs, dependencies, systems -->

--- a/openspec/schemas/spec-driven-custom/templates/spec.md
+++ b/openspec/schemas/spec-driven-custom/templates/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: <!-- requirement name -->
+<!-- requirement text -->
+
+#### Scenario: <!-- scenario name -->
+- **WHEN** <!-- condition -->
+- **THEN** <!-- expected outcome -->

--- a/openspec/schemas/spec-driven-custom/templates/tasks.md
+++ b/openspec/schemas/spec-driven-custom/templates/tasks.md
@@ -1,0 +1,9 @@
+## 1. <!-- Task Group Name -->
+
+- [ ] 1.1 <!-- Task description -->
+- [ ] 1.2 <!-- Task description -->
+
+## 2. <!-- Task Group Name -->
+
+- [ ] 2.1 <!-- Task description -->
+- [ ] 2.2 <!-- Task description -->

--- a/openspec/specs/timeline-flow-coordination/spec.md
+++ b/openspec/specs/timeline-flow-coordination/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Timeline state is assembled atomically from both flows
+`TimelineViewModel` SHALL derive `uiState` by combining the article load state and the read-state flow using `combine()`, so that every emission of `uiState` reflects a consistent snapshot of both sources.
+
+#### Scenario: Both flows emit concurrently
+- **WHEN** the article load state updates while read-state is also updating
+- **THEN** `uiState` SHALL only emit states where articles and readIds are from the same combined snapshot — never a partial mix of old and new values
+
+#### Scenario: Initial state before any fetch
+- **WHEN** `TimelineViewModel` is constructed
+- **THEN** `uiState` SHALL immediately emit `TimelineUiState(isLoading = true, articles = emptyList(), readIds = emptySet())`
+
+### Requirement: Refresh triggers a new article fetch without disrupting read-state observation
+`TimelineViewModel.refresh()` SHALL cancel any in-progress article fetch, set `isLoading = true`, and re-fetch articles — while the read-state flow continues uninterrupted.
+
+#### Scenario: Refresh while read-state has items
+- **WHEN** `readIds` contains one or more IDs and `refresh()` is called
+- **THEN** `uiState` during loading SHALL still reflect the current `readIds` (not reset to empty)
+
+#### Scenario: Successful refresh
+- **WHEN** `refresh()` completes successfully
+- **THEN** `uiState` SHALL emit `isLoading = false` with the newly fetched articles and the current `readIds`
+
+### Requirement: Article fetch errors are surfaced without affecting read-state
+When `ArticleRepository.getArticles()` throws, `TimelineViewModel` SHALL update `uiState.error` and set `isLoading = false`, while `readIds` retains its current value.
+
+#### Scenario: Repository throws during refresh
+- **WHEN** `ArticleRepository.getArticles()` throws a `RuntimeException`
+- **THEN** `uiState` SHALL emit `isLoading = false`, `error` set to the exception message, and `readIds` unchanged
+
+### Requirement: Marking an article read updates uiState.readIds
+Calling `markRead(articleId)` SHALL persist the ID via `ReadStateRepository` and the combined flow SHALL propagate the updated `readIds` into the next `uiState` emission.
+
+#### Scenario: Mark a single article read
+- **WHEN** `markRead("some-id")` is called
+- **THEN** `uiState.readIds` SHALL contain `"some-id"` in the next emission


### PR DESCRIPTION
## Summary

- Replace the dual-coroutine pattern in `TimelineViewModel` (separate `readIds` collector + article fetch, both writing to a shared `MutableStateFlow`) with `combine(_articlesState, readStateRepository.getReadIds()).stateIn(Eagerly)` so every `uiState` emission reflects a consistent snapshot of both sources
- Fix `runCatching` swallowing `CancellationException` in `refresh()`, which caused a cancelled in-flight fetch to write a spurious error to state
- Update tests to work with the async `combine()` propagation using `hangAfterCalls` + `runCurrent()`; add coverage for cancellation safety, error recovery, and readIds preservation during refresh

## Test plan

- [x] All existing `TimelineViewModelTest` and `TimelineScreenTest` tests pass
- [x] New tests: readIds preserved during refresh, cancellation produces no error, error clears on retry, readIds updates while loading
- [x] Full unit test suite green (`./gradlew :app:testDebugUnitTest`)

Closes #41
Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)